### PR TITLE
Fix camelCasing on GET /leases results

### DIFF
--- a/cmd/lambda/leases/main.go
+++ b/cmd/lambda/leases/main.go
@@ -435,7 +435,13 @@ func router(ctx context.Context, req *events.APIGatewayProxyRequest) (
 			return response.ServerErrorWithResponse(fmt.Sprintf("Error querying leases: %s", err)), nil
 		}
 
-		responseBytes, err := json.Marshal(result.Results)
+		// Convert DB Lease model to API Response model
+		leaseResponseItems := []response.LeaseResponse{}
+		for _, lease := range result.Results {
+			leaseResponseItems = append(leaseResponseItems, response.LeaseResponse(*lease))
+		}
+
+		responseBytes, err := json.Marshal(leaseResponseItems)
 
 		if err != nil {
 			return response.ServerErrorWithResponse(fmt.Sprintf("Error serializing response: %s", err)), nil

--- a/tests/acceptance/api_test.go
+++ b/tests/acceptance/api_test.go
@@ -872,6 +872,21 @@ func TestApi(t *testing.T) {
 	})
 
 	t.Run("Get Leases", func(t *testing.T) {
+
+		t.Run("should return empty for no leases", func (t *testing.T) {
+			defer truncateLeaseTable(t, dbSvc)
+
+			resp := apiRequest(t, &apiRequestInput{
+				method: "GET",
+				url:    apiURL + "/leases",
+				json:   nil,
+			})
+
+			results := parseResponseArrayJSON(t, resp)
+
+			assert.Equal(t, results, []map[string]interface{}{}, "API should return []")
+		})
+
 		defer truncateLeaseTable(t, dbSvc)
 
 		accountIDOne := "1"
@@ -930,6 +945,11 @@ func TestApi(t *testing.T) {
 
 			results := parseResponseArrayJSON(t, resp)
 			assert.Equal(t, 5, len(results), "all five leases should be returned")
+
+			// Check one of the result objects, to make sure it looks right
+			assert.Equal(t, results[0]["accountId"], "1")
+			assert.Equal(t, results[0]["principalId"], "a")
+			assert.Equal(t, results[0]["leaseStatus"], "Active")
 		})
 
 		t.Run("When there is an account ID parameter", func(t *testing.T) {


### PR DESCRIPTION
Fix for camelCasing in GET /leases API endpoint
for PR #46 

![image](https://user-images.githubusercontent.com/1153371/66347519-2757d580-e91a-11e9-9737-7a2ef214fdc0.png)
