### PR TITLE
Support `metadata` in /accounts endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## vNext
+
+- Support `metadata` parameter in `/accounts` API endpoints
+
 ## v0.20.0
 
 - Fixed a bug in a migration script

--- a/cmd/lambda/accounts/create.go
+++ b/cmd/lambda/accounts/create.go
@@ -47,10 +47,15 @@ type createController struct {
 // publish the account creation to its respective client
 func (c createController) Call(ctx context.Context, req *events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	// Marshal the request JSON into a CreateRequest object
-	var request createRequest
+	var request accountCreateRequest
 	err := json.Unmarshal([]byte(req.Body), &request)
 	if err != nil {
 		return response.RequestValidationError("invalid request parameters"), nil
+	}
+
+	// Set default metadata={}
+	if request.Metadata == nil {
+		request.Metadata = map[string]interface{}{}
 	}
 
 	// Validate the request body
@@ -90,6 +95,7 @@ func (c createController) Call(ctx context.Context, req *events.APIGatewayProxyR
 		LastModifiedOn: now,
 		CreatedOn:      now,
 		AdminRoleArn:   request.AdminRoleArn,
+		Metadata:       request.Metadata,
 	}
 
 	// Create an IAM Role for the Redbox principal (end-user) to login to
@@ -135,14 +141,15 @@ func (c createController) Call(ctx context.Context, req *events.APIGatewayProxyR
 	), nil
 }
 
-type createRequest struct {
-	ID           string `json:"id"`
-	AdminRoleArn string `json:"adminRoleArn"`
+type accountCreateRequest struct {
+	ID           string                 `json:"id"`
+	AdminRoleArn string                 `json:"adminRoleArn"`
+	Metadata     map[string]interface{} `json:"metadata"`
 }
 
 // Validate - Checks if the Account Request has the provided id and adminRoleArn
 // fields
-func (req *createRequest) Validate() (bool, *events.APIGatewayProxyResponse) {
+func (req *accountCreateRequest) Validate() (bool, *events.APIGatewayProxyResponse) {
 	isValid := true
 	var validationErrors []error
 	if req.ID == "" {


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Add `metadata` parameter support to the `GET` and `POST /accounts` API endpoints.

Note that this does not yet introduce the ability to update account metadata, as there is not yet a `PUT /accounts` endpoint. I will be introducing a `PUT /accounts` endpoint with this behavior in a future PR.

Also, a few minor var renames, to make things more clear as I'm reading through it.

## Types of changes

<!--
What types of changes does your code introduce to the module?
Put an `x` in the boxes that apply
-->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have filled out this PR template
- [x] I have read the [CONTRIBUTING](https://github.com/Optum/Redbox/blob/master/docs/CONTRIBUTING.md) doc
- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (`README.md`, inline comments, etc.)
- [x] I have updated the `CHANGELOG.md` under a `## next` release, with a short summary of my changes

