### PR TITLE
Set reset CodeBuild alarm threshold to 10 failures over 5 hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-
 ## vNext
+
 - Added Lease Validation for check against max budget amount, max budget period, principal budget amount and principal budget period
+- Increase the threshold for Reset CodeBuild alarms to 10 failures over 5 hours.
+\
 ## v0.22.0
 
 **BREAKING CHANGES**

--- a/modules/reset_codebuild.tf
+++ b/modules/reset_codebuild.tf
@@ -214,10 +214,13 @@ resource "aws_cloudwatch_metric_alarm" "reset_failed_builds" {
     ProjectName = aws_codebuild_project.reset_build.name
   }
 
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 1
-  threshold           = 0
-  period              = 60
+  # Alarm if 10 or more builds fail within a 5 hour period.
+  # Note that resets against `NotReady` accounts run every 6 hours,
+  # so this will fail if have 10 accounts that fail to reset in one reset cycle.
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 5
+  threshold           = 10
+  period              = 3600
   statistic           = "Sum"
 
   alarm_actions = [aws_sns_topic.alarms_topic.arn]


### PR DESCRIPTION

## Proposed changes

A single reset failure doesn't indicate a significant system failure,
and, assuming you have more than 1 account in your pool, will not
effect end-user experience.

A proposal for a better monitoring system is described in issue #109 

In PR environment
![image](https://user-images.githubusercontent.com/1153371/68504692-2670d700-022b-11ea-8a93-0562e90aaada.png)



## Types of changes

<!--
What types of changes does your code introduce to the module?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (changes to code, which do not change application behavior)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have filled out this PR template
- [x] I have read the [CONTRIBUTING](https://github.com/Optum/dce/blob/master/docs/CONTRIBUTING.md) doc
- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (`README.md`, inline comments, etc.)
- [x] I have updated the `CHANGELOG.md` under a `## next` release, with a short summary of my changes



