### PR TITLE
Fix TF namespace in builds

### DIFF
--- a/pipelines/test-and-create-pr-env.yml
+++ b/pipelines/test-and-create-pr-env.yml
@@ -60,11 +60,7 @@ steps:
   # Configure the namespace used by Terraform
   # May be referenced as an env var (eg. "${NAMESPACE}")
   # Or as a pipeline variable (eg. "$(namespace)")
-  - script: |
-      PR_NUMBER="$(System.PullRequest.PullRequestNumber)"
-      # This is the branch name, or the git tag name
-      NS_BRANCH_OR_TAG="$(Build.SourceBranchName)"
-
+  - bash: |
       # TODO tag name can't be namespace, AWS doesn't like
       # it as a resource name.
       # If it's a tagged version, just call it `release` or something
@@ -80,6 +76,10 @@ steps:
       # See https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#set-in-script
       echo "##vso[task.setvariable variable=namespace]${NS}"
     displayName: "Configure AWS Namespace"
+    env:
+      PR_NUMBER: $(System.PullRequest.PullRequestNumber)
+      # This is the branch name, or the git tag name
+      NS_BRANCH_OR_TAG: $(Build.SourceBranchName)
 
   # terraform init
   - task: TerraformTaskV1@0


### PR DESCRIPTION


## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->


For whatever reason, pipelines suddenly stopped being able to load build vars inline in bash scripts.
End result was the PR builds were attempting to use the `release` namespace (instead of `github-pr-${PR_NUMBER}`)

This new build config syntax seems to fix it.

Failing builds:
![image](https://user-images.githubusercontent.com/1153371/68787510-4b888f80-0607-11ea-9497-322ee8d2788a.png)
https://dev.azure.com/OptumDCE/DCE/_build/results?buildId=1136
https://dev.azure.com/OptumDCE/DCE/_build/results?buildId=1135

## Types of changes

<!--
What types of changes does your code introduce to the module?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (changes to code, which do not change application behavior)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have filled out this PR template
- [x] I have read the [CONTRIBUTING](https://github.com/Optum/dce/blob/master/docs/CONTRIBUTING.md) doc
- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (`README.md`, inline comments, etc.)
- [ ] N/A ~I have updated the `CHANGELOG.md` under a `## next` release, with a short summary of my changes~


## Dependencies and Blockers



<!--

Is there anything preventing this PR from being merged and deployed to prod?

eg. other PRs that are required, external blockers, etc.

If so, this is a high-risk deployment, and we should call this out for manual attention

-->


## Relevant Links

<!--
Include any links that may be useful for reviewers. This could include

- Related Pull Requests that are waiting for review,
- Relevant 3rd party documentation
- etc.
-->


## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->


