### PR TITLE
Run builds on tags

### DIFF
--- a/pipelines/pipeline.yml
+++ b/pipelines/pipeline.yml
@@ -1,7 +1,11 @@
 pool:
   vmImage: "Ubuntu 16.04"
 
-trigger: none
+trigger:
+  # Run build on tagged versions
+  tags:
+    include:
+      - "v*"
 
 # Run builds for PRs against `master`
 pr:


### PR DESCRIPTION
so we can run release builds

Looks like we lost this build trigger, when we moved to our new pipeline.
See https://github.com/Optum/dce/blob/81c338619a271658de2f59c2c45a27fcb22d0e60/pipelines/test-and-create-pr-env.yml#L9-L12
