### PR TITLE
Fix namespace="$(System.PullRequest.PullRequestNumber)" for tagged releases

### DIFF
--- a/pipelines/pipeline.yml
+++ b/pipelines/pipeline.yml
@@ -108,13 +108,14 @@ stages:
                 # May be referenced as an env var (eg. "${NAMESPACE}")
                 # Or as a pipeline variable (eg. "$(namespace)")
                 - bash: |
-                    # TODO tag name can't be namespace, AWS doesn't like
-                    # it as a resource name.
-                    # If it's a tagged version, just call it `release` or something
-                    if [[ -z ${PR_NUMBER} ]]; then
-                      NS="release"
-                    else
+                    # Use the PR number in the namespace
+                    # so each PR gets its own DCE env.
+                    # Note that sometimes Azure DevOps fails to provide
+                    # the PR number, and the var resolves to "$(System.PullRequest.PullRequestNumber)"
+                    if [[ "${PR_NUMBER}" != *'System.'* ]]; then
                       NS="github-pr-${PR_NUMBER}"
+                    else
+                      NS="cd"
                     fi
 
                     echo "Namespace is ${NS}"


### PR DESCRIPTION
## Proposed changes

Azure Pipelines was setting TF `namespace=github-pr-"$(System.PullRequest.PullRequestNumber)" ` on tagged release builds, which was causing builds to fail.

This works around the Azure bug, by just setting `namespace="github-pr-cd"` (as in "Continuous Deployment") if the namespace gets messed up like this again.



## Types of changes

<!--
What types of changes does your code introduce to the repo?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (changes to code, which do not change application behavior)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have filled out this PR template
- [x] I have read the [CONTRIBUTING](https://github.com/Optum/dce/blob/master/docs/CONTRIBUTING.md) doc
- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (`README.md`, inline comments, etc.)
- [x] I have updated the `CHANGELOG.md` under a `## next` release, with a short summary of my changes


## Relevant Links

<!--
Include any links that may be useful for reviewers. This could include

- Related Pull Requests that are waiting for review,
- Relevant 3rd party documentation
- etc.
-->


## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->


