### PR TITLE
Fix missing nuke regions / principal budget amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 - Support query params for `GET /accounts` endpoint
 - Fixed bug causing dce auth web page to fail
+- Fix incorrect `POST /leases` validation errors on principal budget (#214)
+- Fix missing regions config from nuke template (#221)
 
 ## v0.24.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed bug causing dce auth web page to fail
 - Fix incorrect `POST /leases` validation errors on principal budget (#214)
 - Fix missing regions config from nuke template (#221)
+- Add `execute-api:*` to DCE Principal policy (#224)
 
 ## v0.24.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
 
 ## vNext
 
+- **BREAKING CHANGE:** Set the default allowed regions to us-east-1 only
 - Support query params for `GET /accounts` endpoint
 - Fixed bug causing dce auth web page to fail
 - Fix incorrect `POST /leases` validation errors on principal budget (#214)
 - Fix missing regions config from nuke template (#221)
 - Add `execute-api:*` to DCE Principal policy (#224)
+
+**Migration Notes**
+
+This release changes the list of allowed regions to only include `us-east-1` by default. This is in order to reduce the time it takes for account reset CodeBuilds to run. Previously, these codebuilds would take 1h+ to nuke the 18 default regions, even on an empty account. 
+
+The list of allowed regions is configurable as an `allowed_regions` Terraform variable, and may be set to any region names supported by AWS.
 
 ## v0.24.1
 

--- a/cmd/codebuild/reset/main.go
+++ b/cmd/codebuild/reset/main.go
@@ -221,7 +221,7 @@ func generateNukeConfig(svc *service, f io.Writer) error {
 		AdminRole:       config.accountAdminRoleName,
 		PrincipalRole:   config.accountPrincipalRoleName,
 		PrincipalPolicy: config.accountPrincipalPolicyName,
-		Regions:         config.allowedRegions,
+		Regions:         config.nukeRegions,
 	})
 	if err != nil {
 		log.Printf("Failed to generate nuke config for acount %s using template %s: %s",

--- a/cmd/codebuild/reset/main.go
+++ b/cmd/codebuild/reset/main.go
@@ -154,7 +154,7 @@ func nukeAccount(svc *service, isDryRun bool) error {
 		return err
 	}
 	log.Println("Rendered nuke file:")
-	log.Print(conf)
+	log.Print(string(conf))
 
 	// Construct Nuke
 	nuke := reset.Nuke{}

--- a/cmd/codebuild/reset/main.go
+++ b/cmd/codebuild/reset/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"os"
 	"text/template"
@@ -146,6 +147,14 @@ func nukeAccount(svc *service, isDryRun bool) error {
 	if err != nil {
 		return err
 	}
+
+	// Print the contents of the config file, for logging/debugging
+	conf, err := ioutil.ReadFile(configFile)
+	if err != nil {
+		return err
+	}
+	log.Println("Rendered nuke file:")
+	log.Print(conf)
 
 	// Construct Nuke
 	nuke := reset.Nuke{}

--- a/cmd/codebuild/reset/main_test.go
+++ b/cmd/codebuild/reset/main_test.go
@@ -126,7 +126,7 @@ func TestResetPipeline(t *testing.T) {
 		_config = &serviceConfig{
 			accountID:                  "ABC123",
 			accountAdminRoleName:       "AdminRole",
-			allowedRegions:             []string{"us-east-1", "us-west-1"},
+			nukeRegions:                []string{"us-east-1", "us-west-1"},
 			accountPrincipalRoleName:   "PrincipalRole",
 			accountPrincipalPolicyName: "PrincipalPolicy",
 			nukeTemplateDefault:        "default-nuke-config-template.yml",

--- a/cmd/codebuild/reset/service.go
+++ b/cmd/codebuild/reset/service.go
@@ -37,7 +37,7 @@ type serviceConfig struct {
 	accountPrincipalPolicyName string
 	accountAdminRoleName       string
 	accountAdminRoleARN        string
-	allowedRegions             []string
+	nukeRegions                []string
 
 	isNukeEnabled       bool
 	nukeTemplateDefault string
@@ -62,6 +62,7 @@ func (svc *service) config() *serviceConfig {
 		nukeTemplateDefault: common.RequireEnv("RESET_NUKE_TEMPLATE_DEFAULT"),
 		nukeTemplateBucket:  common.RequireEnv("RESET_NUKE_TEMPLATE_BUCKET"),
 		nukeTemplateKey:     common.RequireEnv("RESET_NUKE_TEMPLATE_KEY"),
+		nukeRegions:         common.RequireEnvStringSlice("RESET_NUKE_REGIONS", ","),
 	}
 	return _config
 }

--- a/cmd/codebuild/reset/service_test.go
+++ b/cmd/codebuild/reset/service_test.go
@@ -22,13 +22,15 @@ func TestService(t *testing.T) {
 		"RESET_NUKE_TEMPLATE_KEY",
 	}
 	for _, envKey := range envVars {
-		err := os.Setenv(envKey, envKey+"_VAL")
-		require.Nil(t, err)
+		_ = os.Setenv(envKey, envKey+"_VAL")
 	}
 
 	// Set toggle env vars
-	err := os.Setenv("RESET_NUKE_TOGGLE", "true")
-	require.Nil(t, err)
+	_ = os.Setenv("RESET_NUKE_TOGGLE", "true")
+
+	// Set regions env var
+	_ = os.Setenv("RESET_NUKE_REGIONS", "us-east-1,us-west-1")
+
 	t.Run("getConfig", func(t *testing.T) {
 
 		t.Run("should configure from env vars", func(t *testing.T) {
@@ -45,6 +47,7 @@ func TestService(t *testing.T) {
 			require.Equal(t, "RESET_NUKE_TEMPLATE_DEFAULT_VAL", config.nukeTemplateDefault)
 			require.Equal(t, "RESET_NUKE_TEMPLATE_BUCKET_VAL", config.nukeTemplateBucket)
 			require.Equal(t, "RESET_NUKE_TEMPLATE_KEY_VAL", config.nukeTemplateKey)
+			require.Equal(t, []string{"us-east-1","us-west-1"}, config.nukeRegions)
 
 			// Check computed config vals
 			require.Equal(t, "arn:aws:iam::RESET_ACCOUNT_VAL:role/RESET_ACCOUNT_ADMIN_ROLE_NAME_VAL", config.accountAdminRoleARN)

--- a/cmd/codebuild/reset/service_test.go
+++ b/cmd/codebuild/reset/service_test.go
@@ -47,7 +47,7 @@ func TestService(t *testing.T) {
 			require.Equal(t, "RESET_NUKE_TEMPLATE_DEFAULT_VAL", config.nukeTemplateDefault)
 			require.Equal(t, "RESET_NUKE_TEMPLATE_BUCKET_VAL", config.nukeTemplateBucket)
 			require.Equal(t, "RESET_NUKE_TEMPLATE_KEY_VAL", config.nukeTemplateKey)
-			require.Equal(t, []string{"us-east-1","us-west-1"}, config.nukeRegions)
+			require.Equal(t, []string{"us-east-1", "us-west-1"}, config.nukeRegions)
 
 			// Check computed config vals
 			require.Equal(t, "arn:aws:iam::RESET_ACCOUNT_VAL:role/RESET_ACCOUNT_ADMIN_ROLE_NAME_VAL", config.accountAdminRoleARN)

--- a/cmd/lambda/leases/create.go
+++ b/cmd/lambda/leases/create.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 
@@ -29,10 +28,11 @@ type createLeaseRequest struct {
 func CreateLease(w http.ResponseWriter, r *http.Request) {
 
 	c := leaseValidationContext{
-		maxLeaseBudgetAmount:     aws.Float64Value(maxLeaseBudgetAmount),
-		maxLeasePeriod:           aws.Int64Value(maxLeasePeriod),
-		defaultLeaseLengthInDays: aws.IntValue(defaultLeaseLengthInDays),
-		principalBudgetPeriod:    aws.StringValue(principalBudgetPeriod),
+		maxLeaseBudgetAmount:     *maxLeaseBudgetAmount,
+		maxLeasePeriod:           *maxLeasePeriod,
+		defaultLeaseLengthInDays: *defaultLeaseLengthInDays,
+		principalBudgetPeriod:    *principalBudgetPeriod,
+		principalBudgetAmount:    *principalBudgetAmount,
 	}
 
 	// Extract the Body from the Request

--- a/cmd/lambda/leases/validate.go
+++ b/cmd/lambda/leases/validate.go
@@ -78,7 +78,10 @@ func validateLeaseFromRequest(context *leaseValidationContext, req *http.Request
 	}
 
 	if spent > context.principalBudgetAmount {
-		validationErrStr := fmt.Sprintf("Unable to create lease: User principal %s has already spent %f of their principal budget", requestBody.PrincipalID, math.Round(context.principalBudgetAmount))
+		validationErrStr := fmt.Sprintf(
+			"Unable to create lease: User principal %s has already spent %.2f of their %.2f principal budget",
+			requestBody.PrincipalID, spent, context.principalBudgetAmount,
+		)
 		return requestBody, false, validationErrStr, nil
 	}
 

--- a/docs/howto.md
+++ b/docs/howto.md
@@ -637,6 +637,11 @@ Budget notification email templates are rendered using [golang templates](https:
 | ActualSpend | The calculated spend on the account at time of notification |
 | ThresholdPercentile | The configured threshold percentage for the notification |
 
+### AWS Regions
+
+By default, DCE users are limited to working in `us-east-1` by IAM Policy. Limiting users to a small number of regions reduces the amount of time it takes to reset accounts. 
+
+To override this behavior, you may set the terraform `allowed_regions` variable to a list of AWS region names.
 
 ## Backup DCE Database Tables
 

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -95,6 +95,7 @@ Implementing DCE in an AWS Organization provides the ability to use SCPs, which 
                 "elastictranscoder:*",
                 "es:*",
                 "events:*",
+                "execute-api:*",
                 "firehose:*",
                 "fsx:*",
                 "glue:*",

--- a/modules/fixtures/policies/principal_policy.tmpl
+++ b/modules/fixtures/policies/principal_policy.tmpl
@@ -110,6 +110,7 @@
         "elastictranscoder:*",
         "es:*",
         "events:*",
+        "execute-api:*",
         "firehose:*",
         "fsx:*",
         "glue:*",

--- a/modules/reset_codebuild.tf
+++ b/modules/reset_codebuild.tf
@@ -108,14 +108,8 @@ resource "aws_codebuild_project" "reset_build" {
     }
 
     environment_variable {
-      name  = "RESET_NAMESPACE"
-      value = var.namespace
-      type  = "PLAINTEXT"
-    }
-
-    environment_variable {
-      name  = "IS_PR"
-      value = local.isPr ? "true" : "false"
+      name  = "RESET_NUKE_REGIONS"
+      value = join("," var.allowed_regions)
       type  = "PLAINTEXT"
     }
 

--- a/modules/reset_codebuild.tf
+++ b/modules/reset_codebuild.tf
@@ -109,7 +109,7 @@ resource "aws_codebuild_project" "reset_build" {
 
     environment_variable {
       name  = "RESET_NUKE_REGIONS"
-      value = join("," var.allowed_regions)
+      value = join(",", var.allowed_regions)
       type  = "PLAINTEXT"
     }
 

--- a/modules/variables.tf
+++ b/modules/variables.tf
@@ -198,25 +198,6 @@ variable "principal_budget_period" {
 
 variable "allowed_regions" {
   type = list(string)
-  default = [
-    "us-east-2",
-    "us-east-1",
-    "us-west-1",
-    "us-west-2",
-    "ap-east-1",
-    "ap-south-1",
-    "ap-northeast-3",
-    "ap-northeast-2",
-    "ap-southeast-1",
-    "ap-southeast-2",
-    "ap-northeast-1",
-    "ca-central-1",
-    "eu-central-1",
-    "eu-west-1",
-    "eu-west-2",
-    "eu-west-3",
-    "eu-north-1",
-    "me-south-1",
-    "sa-east-1"
-  ]
+  default = ["us-east-1"]
+  description = "List of AWS regions which DCE Principals have access to. These regions will also be targeted for reset in nuke.yml."
 }

--- a/modules/variables.tf
+++ b/modules/variables.tf
@@ -198,6 +198,8 @@ variable "principal_budget_period" {
 
 variable "allowed_regions" {
   type = list(string)
-  default = ["us-east-1"]
+  default = [
+    "us-east-1"
+  ]
   description = "List of AWS regions which DCE Principals have access to. These regions will also be targeted for reset in nuke.yml."
 }

--- a/tests/acceptance/api_test.go
+++ b/tests/acceptance/api_test.go
@@ -1735,7 +1735,7 @@ func TestApi(t *testing.T) {
 		})
 
 		t.Run("Should validate requested budget amount against principal budget amount", func(t *testing.T) {
-
+			truncateUsageTable(t, usageSvc)
 			defer truncateUsageTable(t, usageSvc)
 			createUsage(t, apiURL, usageSvc)
 
@@ -1766,9 +1766,12 @@ func TestApi(t *testing.T) {
 			// Verify error response json
 			// Get nested json in response json
 			err := data["error"].(map[string]interface{})
-			errStr := fmt.Sprintf("Unable to create lease: User principal %s has already spent 0.000000 of their principal budget", principalID)
 			require.Equal(t, "RequestValidationError", err["code"].(string))
-			require.Equal(t, errStr, err["message"].(string))
+			require.Equal(t,
+				"Unable to create lease: User principal TestUser1 " +
+				"has already spent 10000.00 of their 1000.00 principal budget",
+				err["message"].(string),
+			)
 		})
 
 	})
@@ -2071,6 +2074,7 @@ func parseResponseArrayJSON(t *testing.T, resp *apiResponse) []map[string]interf
 	// Go doesn't allow you to cast directly to []map[string]interface{}
 	// so we need to mess around here a bit.
 	// This might be relevant: https://stackoverflow.com/questions/38579485/golang-convert-slices-into-map
+	require.IsTypef(t, []interface{}{}, resp.json, "Expected JSON array response, got %v", resp.json)
 	respJSON := resp.json.([]interface{})
 
 	arrJSON := []map[string]interface{}{}

--- a/tests/acceptance/api_test.go
+++ b/tests/acceptance/api_test.go
@@ -1768,8 +1768,8 @@ func TestApi(t *testing.T) {
 			err := data["error"].(map[string]interface{})
 			require.Equal(t, "RequestValidationError", err["code"].(string))
 			require.Equal(t,
-				"Unable to create lease: User principal TestUser1 " +
-				"has already spent 10000.00 of their 1000.00 principal budget",
+				"Unable to create lease: User principal TestUser1 "+
+					"has already spent 10000.00 of their 1000.00 principal budget",
 				err["message"].(string),
 			)
 		})


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

We had some configurations that weren't completely wired into our system.

Fixes #214 
Fixes #221 

**EDIT** Added DCE Principal policy change to allow `execute-api:Invoke` (fixes #224 ). This was blocking me from running functional tests locally, and it's a quick fix.

**EDIT** Changed default `allowed_regions` to just `us-east-1`. I was testing out nuke, and my codebuilt took >1hr to complete with the default 18 regions. I don't think that's good default behavior.

![image](https://user-images.githubusercontent.com/1153371/72562108-4991b580-3870-11ea-9afa-81a6b7f80375.png)


I've tested this out in our nonprod environment, to verify that:
- Nuke runs successfully, and targets the requested resources
- I can create a another lease for the same principal, even after accumulating spend in the Usage db
- I get a 400 if I try to create a lease, when my principal is over budget for the week

## Types of changes

<!--
What types of changes does your code introduce to the repo?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have filled out this PR template
- [x] I have read the [CONTRIBUTING](https://github.com/Optum/dce/blob/master/docs/CONTRIBUTING.md) doc
- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (`README.md`, inline comments, etc.)
- [x] I have updated the `CHANGELOG.md` under a `## next` release, with a short summary of my changes


