### PR TITLE
Changelog update v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 
-## vNext
+## v0.25.0
 
 - **BREAKING CHANGE:** Set the default allowed regions to us-east-1 only
 - Support query params for `GET /accounts` endpoint


### PR DESCRIPTION
## v0.25.0

- **BREAKING CHANGE:** Set the default allowed regions to us-east-1 only
- Support query params for `GET /accounts` endpoint
- Fixed bug causing dce auth web page to fail
- Fix incorrect `POST /leases` validation errors on principal budget (#214)
- Fix missing regions config from nuke template (#221)
- Add `execute-api:*` to DCE Principal policy (#224)

**Migration Notes**

This release changes the list of allowed regions to only include `us-east-1` by default. This is in order to reduce the time it takes for account reset CodeBuilds to run. Previously, these codebuilds would take 1h+ to nuke the 18 default regions, even on an empty account. 

The list of allowed regions is configurable as an `allowed_regions` Terraform variable, and may be set to any region names supported by AWS.