### PR TITLE
Add `sts:*` to Principal IAM policy + SCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add CloudWatch Dashboard for monitoring DCE
 - Support deleting a lease by ID at `GET /leases/{ID}` endpoint
 - Update `GET /accounts` to allow for querying with `adminRoleArn`, `principalRoleArn`, and `principalPolicyHash`
+- Add `sts:*` to principal IAM policy, and to documented SCP
 
 ## v0.26.0
 

--- a/docs/iam-policies.md
+++ b/docs/iam-policies.md
@@ -164,6 +164,7 @@ Implementing DCE in an AWS Organization provides the ability to use SCPs, which 
                 "ssm:*",
                 "states:*",
                 "storagegateway:*",
+                "sts:*",
                 "waf-regional:*",
                 "waf:*",
                 "workspaces:*"

--- a/modules/fixtures/policies/principal_policy.tmpl
+++ b/modules/fixtures/policies/principal_policy.tmpl
@@ -149,6 +149,7 @@
         "ssm:*",
         "states:*",
         "storagegateway:*",
+        "sts:*",
         "waf-regional:*",
         "waf:*",
         "workspaces:*"


### PR DESCRIPTION
## Proposed changes

This will allow DCE principals to assume roles with STS.

The driving force for this change, beyond expanding what DCE users can do in the system, is PR #206, which has us using leases against DCE child accounts to run our functional tests. Our functional tests involve assuming into another role within the same account.

----

To test this out, I manually logged into a nonprod child account leased by PR #206 and added `sts:*` to the DCEPrincipal-nonprod role, then reran the functional tests. This fixed the previously failing tests.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->



## Types of changes

<!--
What types of changes does your code introduce to the repo?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (changes to code, which do not change application behavior)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have filled out this PR template
- [x] I have read the [CONTRIBUTING](https://github.com/Optum/dce/blob/master/docs/CONTRIBUTING.md) doc
- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (`README.md`, inline comments, etc.)
- [x] I have updated the `CHANGELOG.md` under a `## next` release, with a short summary of my changes


