### PR TITLE
switch from strings to json for the sqs reset queue

### DIFF
--- a/cmd/lambda/accounts/create.go
+++ b/cmd/lambda/accounts/create.go
@@ -105,7 +105,12 @@ func CreateAccount(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Add Account to Reset Queue
-	err = Queue.SendMessage(&resetQueueURL, &account.ID)
+	body, err := json.Marshal(&account)
+	if err != nil {
+		log.Printf("Failed to add account %s to reset Queue: %s", account.ID, err)
+	}
+	sBody := string(body)
+	err = Queue.SendMessage(&resetQueueURL, &sBody)
 	if err != nil {
 		log.Printf("Failed to add account %s to reset Queue: %s", account.ID, err)
 		response.WriteServerErrorWithResponse(w, "Internal server error")

--- a/cmd/lambda/accounts/create_test.go
+++ b/cmd/lambda/accounts/create_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -302,12 +304,13 @@ func TestCreate(t *testing.T) {
 		Queue = mockQueue
 
 		queueName := "DefaultResetSQSUrl"
-		accountID := "1234567890"
-
+		now := time.Now().Unix()
+		expectedMessage :=
+			fmt.Sprintf("{\"Id\":\"1234567890\",\"AccountStatus\":\"NotReady\",\"LastModifiedOn\":%d,\"CreatedOn\":%d,\"AdminRoleArn\":\"arn:mock\",\"PrincipalRoleArn\":\"arn:aws:iam::1234567890:role/DCEPrincipal\",\"PrincipalPolicyHash\":\"PolicyHash\",\"Metadata\":{}}", now, now)
 		// Should add account to Queue
 		mockQueue.On("SendMessage",
 			&queueName,
-			&accountID,
+			&expectedMessage,
 		).Return(nil)
 		defer mockQueue.AssertExpectations(t)
 

--- a/cmd/lambda/accounts/delete_test.go
+++ b/cmd/lambda/accounts/delete_test.go
@@ -164,14 +164,17 @@ func TestDeleteController_Call(t *testing.T) {
 
 	t.Run("Sending the accountID to the queue", func(t *testing.T) {
 		expectedResetQueueURL := "mock.queue.url"
-		expectedAccountID := "123456789012"
+		expectedAccount := db.Account{
+			ID: "123456789012",
+		}
+		expectedMessage := "{\"Id\":\"123456789012\",\"AccountStatus\":\"\",\"LastModifiedOn\":0,\"CreatedOn\":0,\"AdminRoleArn\":\"\",\"PrincipalRoleArn\":\"\",\"PrincipalPolicyHash\":\"\",\"Metadata\":null}"
 		stub := &commonMocks.Queue{}
-		stub.On("SendMessage", &expectedResetQueueURL, &expectedAccountID).Return(nil)
+		stub.On("SendMessage", &expectedResetQueueURL, &expectedMessage).Return(nil)
 
 		Queue = stub
 
-		sendToResetQueue(expectedAccountID)
-		stub.AssertCalled(t, "SendMessage", &expectedResetQueueURL, &expectedAccountID)
+		sendToResetQueue(&expectedAccount)
+		stub.AssertCalled(t, "SendMessage", &expectedResetQueueURL, &expectedMessage)
 	})
 
 	t.Run("Sending the send SNS", func(t *testing.T) {

--- a/cmd/lambda/leases/main.go
+++ b/cmd/lambda/leases/main.go
@@ -23,7 +23,6 @@ import (
 
 type leaseControllerConfiguration struct {
 	Debug                    string  `env:"DEBUG" defaultEnv:"false"`
-	ResetQueueURL            string  `env:"RESET_SQS_URL" defaultEnv:"DefaultResetSQSUrl"`
 	LeaseAddedTopicARN       string  `env:"LEASE_ADDED_TOPIC" defaultEnv:"DCEDefaultProvisionTopic"`
 	DecommissionTopicARN     string  `env:"DECOMMISSION_TOPIC" defaultEnv:"DefaultDecommissionTopicArn"`
 	CognitoUserPoolID        string  `env:"COGNITO_USER_POOL_ID" defaultEnv:"DefaultCognitoUserPoolId"`
@@ -63,7 +62,6 @@ var (
 	usageSvc           usage.Service
 	leaseAddedTopicARN string
 	//decommissionTopicARN     string
-	//resetQueueURL            string
 	principalBudgetAmount    float64
 	principalBudgetPeriod    string
 	maxLeaseBudgetAmount     float64
@@ -187,7 +185,6 @@ func initConfig() {
 
 	Services = svcBldr
 
-	//resetQueueURL = Config.GetEnvVar("RESET_SQS_URL", "DefaultResetSQSUrl")
 	leaseAddedTopicARN = Config.GetEnvVar("LEASE_ADDED_TOPIC", "DCEDefaultProvisionTopic")
 	//decommissionTopicARN = Config.GetEnvVar("DECOMMISSION_TOPIC", "DefaultDecommissionTopicArn")
 	//cognitoUserPoolId = Config.GetEnvVar("COGNITO_USER_POOL_ID", "DefaultCognitoUserPoolId")

--- a/cmd/lambda/populate_reset_queue/main.go
+++ b/cmd/lambda/populate_reset_queue/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"log"
 
 	"github.com/pkg/errors"
@@ -21,7 +22,12 @@ func addAccountToQueue(accounts []*db.Account, queueURL *string,
 	// FinanceLock Lease status if necessary
 	for _, acct := range accounts {
 		// Send Message
-		err := queue.SendMessage(queueURL, &acct.ID)
+		body, err := json.Marshal(acct)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to add account %s to queue accounts", acct.ID)
+		}
+		sBody := string(body)
+		err = queue.SendMessage(queueURL, &sBody)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to add account %s to queue accounts", acct.ID)
 		}

--- a/cmd/lambda/process_reset_queue/main.go
+++ b/cmd/lambda/process_reset_queue/main.go
@@ -42,17 +42,11 @@ func handler(ctx context.Context) (bool, error) {
 		Client: codeBuildClient,
 	}
 
-	// Construct the ResetInput
-	dbSvc, err := db.NewFromEnv()
-	if err != nil {
-		log.Fatal(err)
-	}
 	resetInput := processresetqueue.ResetInput{
 		ResetQueue:    queue,
 		ResetQueueURL: &queueURL,
 		ResetBuild:    &build,
 		BuildName:     &buildName,
-		DbSvc:         dbSvc,
 	}
 
 	// Call the Reset and return its values

--- a/cmd/lambda/process_reset_queue/main.go
+++ b/cmd/lambda/process_reset_queue/main.go
@@ -7,7 +7,6 @@ import (
 	"log"
 
 	"github.com/Optum/dce/pkg/common"
-	"github.com/Optum/dce/pkg/db"
 	"github.com/Optum/dce/pkg/processresetqueue"
 
 	"github.com/aws/aws-lambda-go/lambda"

--- a/cmd/lambda/publish_lease_events/main_test.go
+++ b/cmd/lambda/publish_lease_events/main_test.go
@@ -115,6 +115,7 @@ func Test_handleRecord(t *testing.T) {
 		shoudEnqueueReset    bool
 		shouldErrorOnEnqueue bool
 		expectedSnsTopic     string
+		transitionAccount    *db.Account
 	}{
 		{
 			name: "Happy path...",
@@ -132,6 +133,9 @@ func Test_handleRecord(t *testing.T) {
 			wantErr:           false,
 			shoudEnqueueReset: true,
 			expectedSnsTopic:  LockedSnsTopic,
+			transitionAccount: &db.Account{
+				ID: "123456789012",
+			},
 		},
 		{
 			name: "Went from inactive to active...",
@@ -149,6 +153,9 @@ func Test_handleRecord(t *testing.T) {
 			wantErr:           false,
 			shoudEnqueueReset: false,
 			expectedSnsTopic:  UnlockedSnsTopic,
+			transitionAccount: &db.Account{
+				ID: "123456789012",
+			},
 		},
 		{
 			name: "Throwing error on enqueue",
@@ -167,6 +174,9 @@ func Test_handleRecord(t *testing.T) {
 			shoudEnqueueReset:    true,
 			shouldErrorOnEnqueue: true,
 			expectedSnsTopic:     LockedSnsTopic,
+			transitionAccount: &db.Account{
+				ID: "123456789012",
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -179,12 +189,12 @@ func Test_handleRecord(t *testing.T) {
 					"123456789012",
 					db.Leased,
 					db.NotReady,
-				).Return(nil, nil)
+				).Return(tt.transitionAccount, nil)
 
 				if tt.shouldErrorOnEnqueue {
-					sqsSvc.On("SendMessage", aws.String(tt.args.input.resetQueueURL), aws.String("123456789012")).Return(errors.New("error enqueuing message"))
+					sqsSvc.On("SendMessage", aws.String(tt.args.input.resetQueueURL), aws.String("{\"Id\":\"123456789012\",\"AccountStatus\":\"\",\"LastModifiedOn\":0,\"CreatedOn\":0,\"AdminRoleArn\":\"\",\"PrincipalRoleArn\":\"\",\"PrincipalPolicyHash\":\"\",\"Metadata\":null}")).Return(errors.New("error enqueuing message"))
 				} else {
-					sqsSvc.On("SendMessage", aws.String(tt.args.input.resetQueueURL), aws.String("123456789012")).Return(nil)
+					sqsSvc.On("SendMessage", aws.String(tt.args.input.resetQueueURL), aws.String("{\"Id\":\"123456789012\",\"AccountStatus\":\"\",\"LastModifiedOn\":0,\"CreatedOn\":0,\"AdminRoleArn\":\"\",\"PrincipalRoleArn\":\"\",\"PrincipalPolicyHash\":\"\",\"Metadata\":null}")).Return(errors.New("error enqueuing message")).Return(nil)
 				}
 			}
 			snsSvc.On("PublishMessage", &tt.expectedSnsTopic, mock.Anything, true).Return(nil, nil)

--- a/cmd/lambda/update_lease_status/main.go
+++ b/cmd/lambda/update_lease_status/main.go
@@ -62,7 +62,6 @@ func main() {
 			budgetSvc:                              &budget.AWSBudgetService{},
 			usageSvc:                               usageSvc,
 			sqsSvc:                                 sqs.New(awsSession),
-			resetQueueURL:                          common.RequireEnv("RESET_QUEUE_URL"),
 			snsSvc:                                 &common.SNS{Client: sns.New(awsSession)},
 			leaseLockedTopicArn:                    common.RequireEnv("LEASE_LOCKED_TOPIC_ARN"),
 			emailSvc:                               &email.SESEmailService{SES: ses.New(awsSession)},
@@ -109,7 +108,6 @@ type lambdaHandlerInput struct {
 	snsSvc                                 common.Notificationer
 	leaseLockedTopicArn                    string
 	sqsSvc                                 awsiface.SQSAPI
-	resetQueueURL                          string
 	emailSvc                               email.Service
 	budgetNotificationFromEmail            string
 	budgetNotificationBCCEmails            []string

--- a/cmd/lambda/update_lease_status/main_test.go
+++ b/cmd/lambda/update_lease_status/main_test.go
@@ -105,7 +105,6 @@ has exceeded its budget of $100. Actual spend is $150
 			snsSvc:                                 snsSvc,
 			leaseLockedTopicArn:                    "lease-locked",
 			sqsSvc:                                 sqsSvc,
-			resetQueueURL:                          "reset-queue-url",
 			emailSvc:                               emailSvc,
 			budgetNotificationFromEmail:            "from@example.com",
 			budgetNotificationBCCEmails:            []string{"bcc@example.com"},

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,7 @@ github.com/aws/aws-lambda-go v1.11.1/go.mod h1:Rr2SMTLeSMKgD45uep9V/NP8tnbCcySgu
 github.com/aws/aws-sdk-go v1.17.8/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.25.36 h1:4+TL/Y2G5hsR1zdfHmjNG1ou1WEqsSWk8v7m1GaDKyo=
 github.com/aws/aws-sdk-go v1.25.36/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.28.9 h1:grIuBQc+p3dTRXerh5+2OxSuWFi0iXuxbFdTSg0jaW0=
 github.com/awslabs/aws-lambda-go-api-proxy v0.5.0 h1:mmzE5dJ2yt23lmWr6QNtCCAA3H0k4DGWsttilSRnSdI=
 github.com/awslabs/aws-lambda-go-api-proxy v0.5.0/go.mod h1:9ZpbR64sd0A73+ylC1tP63Kyz2VhijeDw1O8naJqehA=
 github.com/aymerick/raymond v2.0.2+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/pkg/processresetqueue/reset.go
+++ b/pkg/processresetqueue/reset.go
@@ -6,7 +6,6 @@ import (
 	"log"
 
 	"github.com/Optum/dce/pkg/account"
-	"github.com/Optum/dce/pkg/db"
 
 	"github.com/Optum/dce/pkg/common"
 	"github.com/aws/aws-sdk-go/aws"
@@ -20,7 +19,6 @@ type ResetInput struct {
 	ResetQueueURL *string
 	ResetBuild    common.Builder
 	BuildName     *string
-	DbSvc         db.DBer
 }
 
 // ResetResult is the individual results of a Reset trigger for an AWS
@@ -76,6 +74,7 @@ func Reset(input *ResetInput) (*ResetOutput, error) {
 
 			acct := &account.Account{}
 			if err := json.Unmarshal([]byte(aws.StringValue(message.Body)), &acct); err != nil {
+				log.Printf("failure unmarshaling message: %q: %+v\n", *message.Body, err)
 				failTriggerResetOnAccount(&output, result, "",
 					err.Error())
 				continue
@@ -88,8 +87,8 @@ func Reset(input *ResetInput) (*ResetOutput, error) {
 			// Set Reset Build Env Vars
 			resetBuildEnvironment := map[string]string{
 				"RESET_ACCOUNT":                     accountID,
-				"RESET_ACCOUNT_ADMIN_ROLE_NAME":     acct.AdminRoleArn.IAMResourceName(),
-				"RESET_ACCOUNT_PRINCIPAL_ROLE_NAME": acct.PrincipalRoleArn.IAMResourceName(),
+				"RESET_ACCOUNT_ADMIN_ROLE_NAME":     *acct.AdminRoleArn.IAMResourceName(),
+				"RESET_ACCOUNT_PRINCIPAL_ROLE_NAME": *acct.PrincipalRoleArn.IAMResourceName(),
 			}
 
 			// Trigger Code Pipeline

--- a/pkg/processresetqueue/reset_test.go
+++ b/pkg/processresetqueue/reset_test.go
@@ -1,6 +1,7 @@
 package processresetqueue
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -10,12 +11,11 @@ import (
 
 	"github.com/stretchr/testify/mock"
 
+	"github.com/Optum/dce/pkg/account"
+	"github.com/Optum/dce/pkg/arn"
 	comMocks "github.com/Optum/dce/pkg/common/mocks"
-	"github.com/Optum/dce/pkg/db"
-	dbMocks "github.com/Optum/dce/pkg/db/mocks"
 	"github.com/stretchr/testify/require"
 
-	"github.com/Optum/dce/pkg/common"
 	"github.com/aws/aws-sdk-go/service/sqs"
 )
 
@@ -54,11 +54,21 @@ func (queue *mockQueue) ReceiveMessage(input *sqs.ReceiveMessageInput) (
 	// Create a Message if numLoop is still positive
 	messages := []*sqs.Message{}
 	if queue.NumLoop > 0 {
-		body := fmt.Sprintf("accountId-%d", queue.NumLoop)
+		accountID := fmt.Sprintf("12345678901%d", queue.NumLoop)
+		acct := &account.Account{
+			ID:               &accountID,
+			Status:           account.StatusNotReady.StatusPtr(),
+			AdminRoleArn:     arn.New("aws", "iam", "", accountID, "role/AdminRole"),
+			PrincipalRoleArn: arn.New("aws", "iam", "", accountID, "role/PrincipalRole"),
+		}
+		body, err := json.Marshal(acct)
+		if err != nil {
+			return nil, err
+		}
 		receiptHandle := receiptHandle
 		messageID := "messageId"
 		messages = append(messages, &sqs.Message{
-			Body:          &body,
+			Body:          aws.String(string(body)),
 			ReceiptHandle: &receiptHandle,
 			MessageId:     &messageID,
 		})
@@ -88,15 +98,14 @@ func (queue *mockQueue) DeleteMessage(input *sqs.DeleteMessageInput) (
 // resetTest is the testing structure used for table driven testing on the
 // Reset Function
 type resetTest struct {
-	ResetQueue         common.Queue
-	ResetQueueURL      string
-	BuildError         error
-	ExpectedBuildEnv   map[string]string
-	ExpectedBuildCount int
-	GetAccount         *db.Account
-	GetAccountError    error
-	ExpectedOutput     *ResetOutput
-	ExpectedError      error
+	Name            string
+	QueueLength     int
+	BuildLength     int
+	ResetQueueURL   string
+	BuildError      error
+	GetAccountError error
+	ExpectedOutput  *ResetOutput
+	ExpectedError   error
 }
 
 // TestReset verifies the Reset function works as intended, where it should be
@@ -108,19 +117,10 @@ func TestReset(t *testing.T) {
 	tests := []resetTest{
 		// Test with No Messages Received
 		{
-			ResetQueue:    createMockQueue(0),
+			Name:          "When the queue is empty.  Process nothing with success.",
+			QueueLength:   0,
+			BuildLength:   0,
 			ResetQueueURL: "https://mytesturl.com/123456789012/reset_queue",
-			GetAccount: &db.Account{
-				ID:               "1234567890",
-				AdminRoleArn:     "arn:aws:iam::123456789012:role/AdminRole",
-				PrincipalRoleArn: "arn:aws:iam::123456789012:role/PrincipalRole",
-			},
-			ExpectedBuildCount: 0,
-			ExpectedBuildEnv: map[string]string{
-				"RESET_ACCOUNT":                     "1234567890",
-				"RESET_ACCOUNT_ADMIN_ROLE_NAME":     "AdminRole",
-				"RESET_ACCOUNT_PRINCIPAL_ROLE_NAME": "PrincipalRole",
-			},
 			ExpectedOutput: &ResetOutput{
 				Success:  true,
 				Accounts: map[string]ResetResult{},
@@ -129,23 +129,14 @@ func TestReset(t *testing.T) {
 		},
 		// Test with 1 Message Received
 		{
-			ResetQueue:    createMockQueue(1),
+			Name:          "When the queue has 1 record.  Process 1 record with success.",
+			QueueLength:   1,
+			BuildLength:   1,
 			ResetQueueURL: "https://mytesturl.com/123456789012/reset_queue",
-			GetAccount: &db.Account{
-				ID:               "1234567890",
-				AdminRoleArn:     "arn:aws:iam::123456789012:role/AdminRole",
-				PrincipalRoleArn: "arn:aws:iam::123456789012:role/PrincipalRole",
-			},
-			ExpectedBuildCount: 1,
-			ExpectedBuildEnv: map[string]string{
-				"RESET_ACCOUNT":                     "1234567890",
-				"RESET_ACCOUNT_ADMIN_ROLE_NAME":     "AdminRole",
-				"RESET_ACCOUNT_PRINCIPAL_ROLE_NAME": "PrincipalRole",
-			},
 			ExpectedOutput: &ResetOutput{
 				Success: true,
 				Accounts: map[string]ResetResult{
-					"accountId-1": ResetResult{
+					"123456789011": ResetResult{
 						BuildTrigger:    true,
 						MessageDeletion: true,
 					},
@@ -155,39 +146,30 @@ func TestReset(t *testing.T) {
 		},
 		// Test with 5 Message Received
 		{
-			ResetQueue:    createMockQueue(5),
+			Name:          "When the queue has 5 records.  Process 5 records with success.",
+			QueueLength:   5,
+			BuildLength:   5,
 			ResetQueueURL: "https://mytesturl.com/123456789012/reset_queue",
-			GetAccount: &db.Account{
-				ID:               "1234567890",
-				AdminRoleArn:     "arn:aws:iam::123456789012:role/AdminRole",
-				PrincipalRoleArn: "arn:aws:iam::123456789012:role/PrincipalRole",
-			},
-			ExpectedBuildCount: 5,
-			ExpectedBuildEnv: map[string]string{
-				"RESET_ACCOUNT":                     "1234567890",
-				"RESET_ACCOUNT_ADMIN_ROLE_NAME":     "AdminRole",
-				"RESET_ACCOUNT_PRINCIPAL_ROLE_NAME": "PrincipalRole",
-			},
 			ExpectedOutput: &ResetOutput{
 				Success: true,
 				Accounts: map[string]ResetResult{
-					"accountId-1": ResetResult{
+					"123456789011": ResetResult{
 						BuildTrigger:    true,
 						MessageDeletion: true,
 					},
-					"accountId-2": ResetResult{
+					"123456789012": ResetResult{
 						BuildTrigger:    true,
 						MessageDeletion: true,
 					},
-					"accountId-3": ResetResult{
+					"123456789013": ResetResult{
 						BuildTrigger:    true,
 						MessageDeletion: true,
 					},
-					"accountId-4": ResetResult{
+					"123456789014": ResetResult{
 						BuildTrigger:    true,
 						MessageDeletion: true,
 					},
-					"accountId-5": ResetResult{
+					"123456789015": ResetResult{
 						BuildTrigger:    true,
 						MessageDeletion: true,
 					},
@@ -195,50 +177,12 @@ func TestReset(t *testing.T) {
 			},
 			ExpectedError: nil,
 		},
-		// Test with GetAccount Error
-		{
-			ResetQueue:         createMockQueue(1),
-			ResetQueueURL:      "https://mytesturl.com/123456789012/reset_queue",
-			GetAccountError:    errors.New("Fail to Get Account"),
-			ExpectedBuildCount: 0,
-			ExpectedOutput: &ResetOutput{
-				Success: false,
-				Accounts: map[string]ResetResult{
-					"accountId-1": ResetResult{
-						BuildTrigger:    false,
-						MessageDeletion: false,
-					},
-				},
-			},
-			ExpectedError: errors.New("Error: Could not successfully trigger a reset on all accounts"),
-		},
-		// Test with Invalid Admin Role Arn
-		{
-			ResetQueue:    createMockQueue(1),
-			ResetQueueURL: "https://mytesturl.com/123456789012/reset_queue",
-			GetAccount: &db.Account{
-				AdminRoleArn: "MyArn",
-			},
-			ExpectedBuildCount: 0,
-			ExpectedOutput: &ResetOutput{
-				Success: false,
-				Accounts: map[string]ResetResult{
-					"accountId-1": ResetResult{
-						BuildTrigger:    false,
-						MessageDeletion: false,
-					},
-				},
-			},
-			ExpectedError: errors.New("Error: Could not successfully trigger a reset on all accounts"),
-		},
 		// Test with Message Receive Failure
 		{
-			ResetQueue:    createMockQueue(1),
+			Name:          "When the queue has 1 message and their is a failure recieving the message.  Retun the appropriate error.",
+			QueueLength:   1,
+			BuildLength:   0,
 			ResetQueueURL: "https://mytesturl.com/123456789012/fail_receive",
-			GetAccount: &db.Account{
-				AdminRoleArn: "arn:aws:iam::123456789012:role/AdminRole",
-			},
-			ExpectedBuildCount: 0,
 			ExpectedOutput: &ResetOutput{
 				Success:  false,
 				Accounts: map[string]ResetResult{},
@@ -247,23 +191,14 @@ func TestReset(t *testing.T) {
 		},
 		// Test with Message Delete Failure
 		{
-			ResetQueue:    createMockQueue(1),
+			Name:          "When the queue has 1 message and their is a failure deleting the message.  Retun the appropriate error.",
+			QueueLength:   1,
+			BuildLength:   1,
 			ResetQueueURL: "https://mytesturl.com/123456789012/fail_delete",
-			GetAccount: &db.Account{
-				ID:               "1234567890",
-				AdminRoleArn:     "arn:aws:iam::123456789012:role/AdminRole",
-				PrincipalRoleArn: "arn:aws:iam::123456789012:role/PrincipalRole",
-			},
-			ExpectedBuildCount: 1,
-			ExpectedBuildEnv: map[string]string{
-				"RESET_ACCOUNT":                     "1234567890",
-				"RESET_ACCOUNT_ADMIN_ROLE_NAME":     "AdminRole",
-				"RESET_ACCOUNT_PRINCIPAL_ROLE_NAME": "PrincipalRole",
-			},
 			ExpectedOutput: &ResetOutput{
 				Success: false,
 				Accounts: map[string]ResetResult{
-					"accountId-1": ResetResult{
+					"123456789011": ResetResult{
 						BuildTrigger:    true,
 						MessageDeletion: false,
 					},
@@ -274,24 +209,15 @@ func TestReset(t *testing.T) {
 		},
 		// Test with Trigger Build Failure
 		{
-			ResetQueue:    createMockQueue(1),
+			Name:          "When the queue has 1 message and their is a failure triggering code build.  Retun the appropriate error.",
+			QueueLength:   1,
+			BuildLength:   1,
 			ResetQueueURL: "https://mytesturl.com/123456789012/reset_queue",
 			BuildError:    errors.New("Fail Triggering Build"),
-			GetAccount: &db.Account{
-				ID:               "1234567890",
-				AdminRoleArn:     "arn:aws:iam::123456789012:role/AdminRole",
-				PrincipalRoleArn: "arn:aws:iam::123456789012:role/PrincipalRole",
-			},
-			ExpectedBuildCount: 1,
-			ExpectedBuildEnv: map[string]string{
-				"RESET_ACCOUNT":                     "1234567890",
-				"RESET_ACCOUNT_ADMIN_ROLE_NAME":     "AdminRole",
-				"RESET_ACCOUNT_PRINCIPAL_ROLE_NAME": "PrincipalRole",
-			},
 			ExpectedOutput: &ResetOutput{
 				Success: false,
 				Accounts: map[string]ResetResult{
-					"accountId-1": ResetResult{
+					"123456789011": ResetResult{
 						BuildTrigger:    false,
 						MessageDeletion: false,
 					},
@@ -303,27 +229,28 @@ func TestReset(t *testing.T) {
 	}
 	buildName := "test"
 
-	t.Run("Inputs/Output", func(t *testing.T) {
-		// Iterate through each test in the list
-		for _, test := range tests {
-			// Mock the Database to return test.GetAccount
-			mockDb := &dbMocks.DBer{}
-			mockDb.
-				On("GetAccount", mock.Anything).
-				Return(test.GetAccount, test.GetAccountError)
-
+	// Iterate through each test in the list
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
 			// Mock CodeBuild.StartBuild
 			mockBuilder := &comMocks.Builder{}
-			mockBuilder.On("StartBuild", mock.Anything, test.ExpectedBuildEnv).
-				Return("mock-build-id", test.BuildError)
+			for i := 1; i <= test.BuildLength; i++ {
+				buildEnv := map[string]string{
+					"RESET_ACCOUNT":                     fmt.Sprintf("12345678901%d", i),
+					"RESET_ACCOUNT_ADMIN_ROLE_NAME":     "AdminRole",
+					"RESET_ACCOUNT_PRINCIPAL_ROLE_NAME": "PrincipalRole",
+				}
+				mockBuilder.On("StartBuild", mock.Anything, buildEnv).
+					Return("mock-build-id", test.BuildError)
+			}
 
+			mockQueue := createMockQueue(test.QueueLength)
 			// Set up the ResetInput
 			resetInput := &ResetInput{
-				ResetQueue:    test.ResetQueue,
+				ResetQueue:    mockQueue,
 				ResetQueueURL: &test.ResetQueueURL,
 				ResetBuild:    mockBuilder,
 				BuildName:     &buildName,
-				DbSvc:         mockDb,
 			}
 
 			// Call the Reset function with the Mocked Queue and Pipeline
@@ -334,163 +261,7 @@ func TestReset(t *testing.T) {
 			require.Equal(t, test.ExpectedError, err)
 
 			// Assert that mockBuild was called as expected
-			mockBuilder.AssertNumberOfCalls(t, "StartBuild", test.ExpectedBuildCount)
-		}
-	})
-
-	t.Run("Should set Lease.Status=ResetLock in DB, if the account has active leases", func(t *testing.T) {
-		// Mock the DB Service
-		mockDb := &dbMocks.DBer{}
-		defer mockDb.AssertExpectations(t)
-
-		// Mock leases for our Account
-		// Should set Lease.Status=ResetLock
-		// on the active lease (principalId-1)
-		mockDb.On("GetAccount", mock.Anything).
-			Return(mockAccount(), nil)
-
-		// Mock the Build
-		mockBuild := &comMocks.Builder{}
-		mockBuild.On("StartBuild", mock.Anything, mock.Anything).
-			Return("123", nil)
-
-		// Call Reset
-		queueURL := "https://mytesturl.com/123456789012/reset_queue"
-		resetOutput, err := Reset(&ResetInput{
-			// Will provide account "accountId-1"
-			ResetQueue:    createMockQueue(1),
-			ResetQueueURL: &queueURL,
-			ResetBuild:    mockBuild,
-			BuildName:     &buildName,
-			DbSvc:         mockDb,
+			mockBuilder.AssertExpectations(t)
 		})
-		require.Nil(t, err)
-		require.True(t, resetOutput.Success)
-	})
-
-	t.Run("Should not attempt to set the Lease status, if the account has no leases", func(t *testing.T) {
-		// Mock the DB Service
-		mockDb := &dbMocks.DBer{}
-		defer mockDb.AssertExpectations(t)
-
-		// Mock the DB to return no leases for the account
-		mockDb.On("GetAccount", mock.Anything).
-			Return(mockAccount(), nil)
-
-		// Mock the build, and assert that we do _not_ call it
-		mockBuild := comMocks.Builder{}
-		mockBuild.On("StartBuild", mock.Anything, mock.Anything).
-			Return("123", nil)
-		defer mockBuild.AssertNotCalled(t, "StartBuild")
-
-		// Call Reset
-		queueURL := "https://mytesturl.com/123456789012/reset_queue"
-		resetOutput, err := Reset(&ResetInput{
-			// Will provide account "accountId-1"
-			ResetQueue:    createMockQueue(1),
-			ResetQueueURL: &queueURL,
-			ResetBuild:    &mockBuild,
-			BuildName:     &buildName,
-			DbSvc:         mockDb,
-		})
-		require.Nil(t, err)
-		require.True(t, resetOutput.Success)
-
-		// Check that we didn't attempt to change any
-		// lease statuses
-		mockDb.AssertNotCalled(t, "TransitionLeaseStatus")
-	})
-
-	t.Run("Should return errors from DB", func(t *testing.T) {
-		// Mock the DB to fail on `FindLeasesByAccount`
-		mockDb := &dbMocks.DBer{}
-		defer mockDb.AssertExpectations(t)
-		dbErr := errors.New("Error: Could not successfully trigger a reset on all accounts")
-		mockDb.On("GetAccount", mock.Anything).
-			Return(mockAccount(), dbErr)
-
-		// Mock the Build
-		mockBuild := &comMocks.Builder{}
-		mockBuild.On("StartBuild", mock.Anything, mock.Anything).
-			Return("123", nil)
-
-		// Call Reset
-		queueURL := "https://mytesturl.com/123456789012/reset_queue"
-		_, err := Reset(&ResetInput{
-			// Will provide account "accountId-1"
-			ResetQueue:    createMockQueue(1),
-			ResetQueueURL: &queueURL,
-			ResetBuild:    mockBuild,
-			BuildName:     &buildName,
-			DbSvc:         mockDb,
-		})
-
-		// Check that we get back our error from the DB
-		require.Equal(t, dbErr, err, "Reset should return the DB error")
-	})
-
-	t.Run("Should pass parameters to the build environment", func(t *testing.T) {
-		// Mock the Database
-		mockDb := &dbMocks.DBer{}
-		mockDb.
-			On("FindLeasesByAccount", mock.Anything).
-			Return([]*db.Lease{}, nil)
-		mockDb.
-			On("GetAccount", "accountId-1").
-			Return(&db.Account{
-				ID:               "123456789012",
-				AdminRoleArn:     "arn:aws:iam::123456789012:role/AdminRole",
-				PrincipalRoleArn: "arn:aws:iam::123456789012:role/PrincipalRole",
-			}, nil)
-
-		// Mock the Builder
-		mockBuilder := &comMocks.Builder{}
-		mockBuilder.On("StartBuild",
-			aws.String("mock-build-name"),
-			map[string]string{
-				"RESET_ACCOUNT":                     "123456789012",
-				"RESET_ACCOUNT_ADMIN_ROLE_NAME":     "AdminRole",
-				"RESET_ACCOUNT_PRINCIPAL_ROLE_NAME": "PrincipalRole",
-			},
-		).
-			Return("mock-build-id", nil)
-
-		// Call the Reset function with the Mocked Queue and Pipeline
-		_, err := Reset(&ResetInput{
-			ResetQueue:    createMockQueue(1),
-			ResetQueueURL: aws.String("https://mytesturl.com/123456789012/reset_queue"),
-			ResetBuild:    mockBuilder,
-			BuildName:     aws.String("mock-build-name"),
-			DbSvc:         mockDb,
-		})
-		require.Nil(t, err)
-
-		// Make sure we called builder.StartBuild, with the expected params
-		mockBuilder.AssertExpectations(t)
-	})
-}
-
-func TestExtractRoleNameFromARN(t *testing.T) {
-
-	t.Run("should extract name from valid ARN", func(t *testing.T) {
-		roleName, err := extractRoleNameFromARN(
-			"arn:aws:iam::123456789012:role/myRole",
-		)
-		require.Nil(t, err)
-		require.Equal(t, "myRole", roleName)
-	})
-
-	t.Run("should fail for invalid ARN", func(t *testing.T) {
-		_, err := extractRoleNameFromARN("invalid_arn")
-		require.NotNil(t, err)
-		require.Equal(t, "Invalid Role ARN: invalid_arn", err.Error())
-	})
-}
-
-func mockAccount() *db.Account {
-	return &db.Account{
-		ID:               "123456789012",
-		AdminRoleArn:     "arn:aws:iam::123456789012:role/AdminRole",
-		PrincipalRoleArn: "arn:aws:iam::123456789012:role/PrincipalRole",
 	}
 }


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
- Switch to using JSON messages of the account records when putting messages into the SQS Reset Queue


This will get easier with the other rewrites but for now this is the simplest of the changes to separate the string to json portion.

## Types of changes

<!--
What types of changes does your code introduce to the repo?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (changes to code, which do not change application behavior)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have filled out this PR template
- [ ] I have read the [CONTRIBUTING](https://github.com/Optum/dce/blob/master/docs/CONTRIBUTING.md) doc
- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (`README.md`, inline comments, etc.)
- [ ] I have updated the `CHANGELOG.md` under a `## next` release, with a short summary of my changes


## Relevant Links

<!--
Include any links that may be useful for reviewers. This could include

- Related Pull Requests that are waiting for review,
- Relevant 3rd party documentation
- etc.
-->


## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->


