### PR TITLE
Make Usage DB TTL configurable as TF var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## vNext
 
+- Add `usage_ttl` Terraform var, to configure Usage DB record TTLs.
+
 ## v0.27.0
 
 - Add CloudWatch Dashboard for monitoring DCE

--- a/cmd/lambda/update_lease_status/main.go
+++ b/cmd/lambda/update_lease_status/main.go
@@ -73,6 +73,7 @@ func main() {
 			budgetNotificationThresholdPercentiles: common.RequireEnvFloatSlice("BUDGET_NOTIFICATION_THRESHOLD_PERCENTILES", ","),
 			principalBudgetAmount:                  common.RequireEnvFloat("PRINCIPAL_BUDGET_AMOUNT"),
 			principalBudgetPeriod:                  common.RequireEnv("PRINCIPAL_BUDGET_PERIOD"),
+			usageTTL:                               common.RequireEnvInt("USAGE_TTL"),
 		})
 		if err != nil {
 			log.Fatalf("Failed check budget: %s", err)
@@ -117,6 +118,7 @@ type lambdaHandlerInput struct {
 	budgetNotificationThresholdPercentiles []float64
 	principalBudgetAmount                  float64
 	principalBudgetPeriod                  string
+	usageTTL                               int // TTL in seconds for Usage DynamoDB records
 }
 
 func lambdaHandler(input *lambdaHandlerInput) error {
@@ -143,6 +145,7 @@ func lambdaHandler(input *lambdaHandlerInput) error {
 		usageSvc:              input.usageSvc,
 		awsSession:            input.awsSession,
 		principalBudgetPeriod: input.principalBudgetPeriod,
+		usageTTL:              input.usageTTL,
 	})
 	if err != nil {
 		return errors.Wrapf(err, "Failed to calculate spend for lease %s", leaseLogID)

--- a/cmd/lambda/update_lease_status/main_test.go
+++ b/cmd/lambda/update_lease_status/main_test.go
@@ -113,6 +113,7 @@ has exceeded its budget of $100. Actual spend is $150
 			budgetNotificationTemplateSubject:      emailTemplateSubject,
 			budgetNotificationThresholdPercentiles: []float64{75, 100},
 			principalBudgetAmount:                  1000,
+			usageTTL:                               3600,
 		}
 
 		// Should grab the account from the DB, to get it's adminRoleArn
@@ -137,7 +138,7 @@ has exceeded its budget of $100. Actual spend is $150
 			endDate,
 		).Return(test.actualSpend, nil)
 
-		// Mock Usage service
+		// Expected Usage DB entry
 		inputUsage := usage.Usage{
 			PrincipalID:  "test-user",
 			AccountID:    "",
@@ -145,7 +146,7 @@ has exceeded its budget of $100. Actual spend is $150
 			EndDate:      usageEndDate.Unix(),
 			CostAmount:   test.actualSpend,
 			CostCurrency: "USD",
-			TimeToLive:   startDate.AddDate(0, 1, 0).Unix(),
+			TimeToLive:   startDate.Add(time.Duration(3600) * time.Second).Unix(),
 		}
 
 		budgetStartTime := time.Unix(input.lease.LeaseStatusModifiedOn, 0)

--- a/modules/update_lease_status.tf
+++ b/modules/update_lease_status.tf
@@ -45,6 +45,7 @@ module "update_lease_status_lambda" {
     BUDGET_NOTIFICATION_THRESHOLD_PERCENTILES = join(",", var.budget_notification_threshold_percentiles)
     PRINCIPAL_BUDGET_AMOUNT                   = var.principal_budget_amount
     PRINCIPAL_BUDGET_PERIOD                   = var.principal_budget_period
+    USAGE_TTL                                 = var.usage_ttl
   }
 }
 

--- a/modules/variables.tf
+++ b/modules/variables.tf
@@ -208,3 +208,10 @@ variable "allowed_regions" {
   ]
   description = "List of AWS regions which DCE Principals have access to. These regions will also be targeted for reset in nuke.yml."
 }
+
+variable "usage_ttl" {
+  type = number
+  # 30 days
+  default     = 2592000
+  description = "TTL in seconds for records in the Usage DynamoDB table. Records older than this TTL will be automatically deleted."
+}


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Allow admin users to configure Usage DB record TTLs as a terraform variable.
Default TTL will stay at 30 days, to not break existing deployments.

----

Did a bit of manual QA on this in the PR environment. 
Created a lease, and ran the update_lease_status lambda, to trigger creating a DB record in the usage table:
![image](https://user-images.githubusercontent.com/1153371/73569498-2cdcac80-4430-11ea-8057-e9279f9ffd1d.png)

TTL is `1583020800` or 3/1/20, which is 30 days after the usage `StartTime` ✅ 

## Types of changes

<!--
What types of changes does your code introduce to the repo?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (changes to code, which do not change application behavior)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have filled out this PR template
- [x] I have read the [CONTRIBUTING](https://github.com/Optum/dce/blob/master/docs/CONTRIBUTING.md) doc
- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (`README.md`, inline comments, etc.)
- [x] I have updated the `CHANGELOG.md` under a `## next` release, with a short summary of my changes

