### PR TITLE
Move service getters to ServiceBuilder struct

### DIFF
--- a/cmd/lambda/accounts/create.go
+++ b/cmd/lambda/accounts/create.go
@@ -22,7 +22,7 @@ func CreateAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	account, err := Services.Config.AccountService().Create(newAccount)
+	account, err := Services.AccountService().Create(newAccount)
 	if err != nil {
 		api.WriteAPIErrorResponse(w, err)
 		return

--- a/cmd/lambda/accounts/delete.go
+++ b/cmd/lambda/accounts/delete.go
@@ -12,13 +12,13 @@ func DeleteAccount(w http.ResponseWriter, r *http.Request) {
 
 	accountID := mux.Vars(r)["accountId"]
 
-	acct, err := Services.Config.AccountService().Get(accountID)
+	acct, err := Services.AccountService().Get(accountID)
 	if err != nil {
 		api.WriteAPIErrorResponse(w, err)
 		return
 	}
 
-	err = Services.Config.AccountService().Delete(acct)
+	err = Services.AccountService().Delete(acct)
 	if err != nil {
 		api.WriteAPIErrorResponse(w, err)
 		return

--- a/cmd/lambda/accounts/get.go
+++ b/cmd/lambda/accounts/get.go
@@ -13,7 +13,7 @@ func GetAccountByID(w http.ResponseWriter, r *http.Request) {
 
 	accountID := mux.Vars(r)["accountId"]
 
-	account, err := Services.Config.AccountService().Get(accountID)
+	account, err := Services.AccountService().Get(accountID)
 
 	if err != nil {
 		api.WriteAPIErrorResponse(w, err)

--- a/cmd/lambda/accounts/list.go
+++ b/cmd/lambda/accounts/list.go
@@ -23,7 +23,7 @@ func GetAccounts(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	accounts, err := Services.Config.AccountService().List(query)
+	accounts, err := Services.AccountService().List(query)
 	if err != nil {
 		api.WriteAPIErrorResponse(w, err)
 		return

--- a/cmd/lambda/accounts/update.go
+++ b/cmd/lambda/accounts/update.go
@@ -40,7 +40,7 @@ func UpdateAccountByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	account, err := Services.Config.AccountService().Update(accountID, newAccount)
+	account, err := Services.AccountService().Update(accountID, newAccount)
 	if err != nil {
 		api.WriteAPIErrorResponse(w, err)
 		return

--- a/cmd/lambda/leases/delete.go
+++ b/cmd/lambda/leases/delete.go
@@ -17,7 +17,7 @@ func DeleteLeaseByID(w http.ResponseWriter, r *http.Request) {
 
 	leaseID := mux.Vars(r)["leaseID"]
 
-	lease, err := Services.Config.LeaseService().Delete(leaseID)
+	lease, err := Services.LeaseService().Delete(leaseID)
 
 	if err != nil {
 		api.WriteAPIErrorResponse(w, err)
@@ -52,7 +52,7 @@ func DeleteLease(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	leases, err := Services.Config.LeaseService().List(queryLease)
+	leases, err := Services.LeaseService().List(queryLease)
 	if err != nil {
 		api.WriteAPIErrorResponse(w, err)
 		return
@@ -69,7 +69,7 @@ func DeleteLease(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	leaseID := (*leases)[0].ID
-	lease, err := Services.Config.LeaseService().Delete(*leaseID)
+	lease, err := Services.LeaseService().Delete(*leaseID)
 
 	if err != nil {
 		api.WriteAPIErrorResponse(w, err)

--- a/cmd/lambda/leases/get.go
+++ b/cmd/lambda/leases/get.go
@@ -13,7 +13,7 @@ func GetLeaseByID(w http.ResponseWriter, r *http.Request) {
 
 	leaseID := mux.Vars(r)["leaseID"]
 
-	lease, err := Services.Config.LeaseService().Get(leaseID)
+	lease, err := Services.LeaseService().Get(leaseID)
 
 	if err != nil {
 		api.WriteAPIErrorResponse(w, err)

--- a/cmd/lambda/leases/list.go
+++ b/cmd/lambda/leases/list.go
@@ -22,7 +22,7 @@ func GetLeases(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	leases, err := Services.Config.LeaseService().List(query)
+	leases, err := Services.LeaseService().List(query)
 	if err != nil {
 		api.WriteAPIErrorResponse(w, err)
 		return

--- a/cmd/lambda/populate_reset_queue/main.go
+++ b/cmd/lambda/populate_reset_queue/main.go
@@ -53,13 +53,13 @@ func Handler(cloudWatchEvent events.CloudWatchEvent) error {
 	}
 
 	for {
-		accounts, err := services.Config.AccountService().List(query)
+		accounts, err := services.AccountService().List(query)
 		if err != nil {
 			return err
 		}
 		for _, acct := range *accounts {
 			// Send Message
-			err = services.Config.AccountService().Reset(&acct)
+			err = services.AccountService().Reset(&acct)
 			if err != nil {
 				return err
 			}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,8 +9,6 @@ import (
 	"os"
 	"reflect"
 
-	"github.com/Optum/dce/pkg/account/accountiface"
-	"github.com/Optum/dce/pkg/lease/leaseiface"
 	"github.com/caarlos0/env"
 	"github.com/mitchellh/mapstructure"
 )
@@ -257,26 +255,4 @@ func getKeyPtrs(aMap map[string]ParameterStoreVal) []*string {
 		keys = append(keys, &newK)
 	}
 	return keys
-}
-
-// AccountService returns the account Service for you
-func (config *ConfigurationBuilder) AccountService() accountiface.Servicer {
-
-	var accountService accountiface.Servicer
-	if err := config.GetService(&accountService); err != nil {
-		panic(err)
-	}
-
-	return accountService
-}
-
-// LeaseSvc returns the lease Service for you
-func (config *ConfigurationBuilder) LeaseService() leaseiface.Servicer {
-
-	var leaseSvc leaseiface.Servicer
-	if err := config.GetService(&leaseSvc); err != nil {
-		panic(err)
-	}
-
-	return leaseSvc
 }

--- a/pkg/config/servicebuild.go
+++ b/pkg/config/servicebuild.go
@@ -149,11 +149,33 @@ func (bldr *ServiceBuilder) WithAccountService() *ServiceBuilder {
 	return bldr
 }
 
+// AccountService returns the account Service for you
+func (bldr *ServiceBuilder) AccountService() accountiface.Servicer {
+
+	var accountService accountiface.Servicer
+	if err := bldr.Config.GetService(&accountService); err != nil {
+		panic(err)
+	}
+
+	return accountService
+}
+
 // WithLeaseService tells the builder to add the Account service to the `ConfigurationBuilder`
 func (bldr *ServiceBuilder) WithLeaseService() *ServiceBuilder {
 	bldr.WithLeaseDataService().WithEventService()
 	bldr.handlers = append(bldr.handlers, bldr.createLeaseService)
 	return bldr
+}
+
+// LeaseService returns the lease Service for you
+func (bldr *ServiceBuilder) LeaseService() leaseiface.Servicer {
+
+	var leaseSvc leaseiface.Servicer
+	if err := bldr.Config.GetService(&leaseSvc); err != nil {
+		panic(err)
+	}
+
+	return leaseSvc
 }
 
 // WithEventService tells the builder to add the Account service to the `ConfigurationBuilder`


### PR DESCRIPTION


## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Just moving the the configuration service's `LeaseService()` and `AccountService()` getter methods to the main `ServiceBuilder` struct (were in the `ConfigurationBuilder` struct before)
The actual methods for defining these service (`WithLeaseService()`/`WithAccountService()`) are in the `ServiceBuilder`, so it didn't make much sense to have the getter methods in a different struct.

Ran into this while trying to define a new service, and was trying to understand the existing patterns for doing so.

## Types of changes

<!--
What types of changes does your code introduce to the repo?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (changes to code, which do not change application behavior)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have filled out this PR template
- [x] I have read the [CONTRIBUTING](https://github.com/Optum/dce/blob/master/docs/CONTRIBUTING.md) doc
- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (`README.md`, inline comments, etc.)
- [ ] N/A ~I have updated the `CHANGELOG.md` under a `## next` release, with a short summary of my changes~


