### PR TITLE
Document breaking change in v0.24.0 (aws-nuke --no-dry-run)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The list of allowed regions is configurable as an `allowed_regions` Terraform va
 
 ## v0.24.0
 
+- **BREAKING CHANGE:** Enable aws-nuke to run by default (disable dry-run mode)
 - Update Status Lambda - budget_check: Terminate lease if spend > Principal budget amount
 - Support `metadata` parameter in `/accounts` API endpoints
 - Add `PUT /accounts/:id` endpoint
@@ -52,6 +53,18 @@ The list of allowed regions is configurable as an `allowed_regions` Terraform va
 - Add `GET /auth` and `GET /auth/{file+}` endpoints for retrieving credentials web page
 - Merged quickstarts into how-to guide
 - Support query params for `GET /usage` endpoints
+
+**Migration Notes**
+
+In previous versions of DCE, aws-nuke would run in [_Dry Run Mode_](https://github.com/rebuy-de/aws-nuke#usage) by default, during account resets. This version changes that default behavior, so that aws-nuke runs to completion by default.
+
+If you would like to maintain previous behavior and run aws-nuke in _Dry Run Mode_, you may set the terraform variable:
+
+```hcl
+reset_nuke_toggle = false
+```
+
+See documentation on [_Configuring Terraform Variables_](https://dce.readthedocs.io/en/latest/terraform.html#configuring-terraform-variables).
 
 ## v0.23.0
 


### PR DESCRIPTION
## Proposed changes

We had a breaking in v0.24.0 that was not properly documented.

See https://github.com/Optum/dce/issues/238#issuecomment-585363570
