### PR TITLE
CW Dashboard: Fix reset error scraper query

### DIFF
--- a/modules/fixtures/dashboards/cloudwatch_dashboard.json
+++ b/modules/fixtures/dashboards/cloudwatch_dashboard.json
@@ -86,7 +86,7 @@
       "width": 24,
       "height": 6,
       "properties": {
-        "query": "SOURCE '/aws/codebuild/${codebuild_name}' | ${error_scraper_query}",
+        "query": "SOURCE '/aws/codebuild/${codebuild_name}' | fields @timestamp, @message | sort @timestamp desc | filter @message like /(delete failed|Failed to execute aws-nuke on account)/ | display @timestamp, @message, @logStream| limit 50",
         "region": "us-east-1",
         "stacked": false,
         "view": "table",


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->


    CW Dashboard: Fix reset error scraper, to show actual nuke failure errors
    
    aws-nuke has "error" messages all the time, because of how it works
    (tries to delete everything, until it can)
    
    This filter better matches to actual reset codebuild errors


_Previous query results_
![image](https://user-images.githubusercontent.com/1153371/75167542-25d15300-56eb-11ea-8a80-8b42b1a18842.png)

notice that it matches against "0 failures", because it has the term "fail" in it

_Query results, with proposed changes_

![with changes](https://user-images.githubusercontent.com/1153371/75167695-5f09c300-56eb-11ea-9f9d-1a99d95b2d12.png)

You can expand those logs to see something like:


> time="2020-02-24T13:55:39Z" level=error msg="CloudFormationStack stackName=env-18... attempt=3 maxAttempts=3 delete failed: ValidationError: Stack [env-182438] cannot be deleted while TerminationProtection is enabled\n\tstatus code: 400, request id: 56f...."

which appears to be an actual failure, which we can address (eg, a aws-nuke gap)



