### PR TITLE
Fix to allow budget notification email templates > 4Kb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Update the visibility timeout on the Reset SQS to be 6 times the runtime of the process reset queue Lambda
 - Fix an issue when comparing the current Principal Policy Hash to the new version where the pointers were being compared and not the values
 - Update functional testing timeout to be 20 minutes from the default of 10 minutes
+- Fix to allow budget notification email templates > 4Kb
 
 ## v0.28.0
 

--- a/modules/update_lease_status.tf
+++ b/modules/update_lease_status.tf
@@ -1,3 +1,7 @@
+locals {
+  budget_notification_templates_bucket = aws_s3_bucket.artifacts.id
+}
+
 module "fan_out_update_lease_status_lambda" {
   source          = "./lambda"
   name            = "fan_out_update_lease_status-${var.namespace}"
@@ -39,14 +43,28 @@ module "update_lease_status_lambda" {
     LEASE_LOCKED_TOPIC_ARN                    = aws_sns_topic.lease_locked.arn
     BUDGET_NOTIFICATION_FROM_EMAIL            = var.budget_notification_from_email
     BUDGET_NOTIFICATION_BCC_EMAILS            = join(",", var.budget_notification_bcc_emails)
-    BUDGET_NOTIFICATION_TEMPLATE_HTML         = var.budget_notification_template_html
-    BUDGET_NOTIFICATION_TEMPLATE_TEXT         = var.budget_notification_template_text
+    BUDGET_NOTIFICATION_TEMPLATES_BUCKET      = local.budget_notification_templates_bucket
+    BUDGET_NOTIFICATION_TEMPLATE_HTML_KEY     = aws_s3_bucket_object.budget_notification_template_html.key
+    BUDGET_NOTIFICATION_TEMPLATE_TEXT_KEY     = aws_s3_bucket_object.budget_notification_template_text.key
     BUDGET_NOTIFICATION_TEMPLATE_SUBJECT      = var.budget_notification_template_subject
     BUDGET_NOTIFICATION_THRESHOLD_PERCENTILES = join(",", var.budget_notification_threshold_percentiles)
     PRINCIPAL_BUDGET_AMOUNT                   = var.principal_budget_amount
     PRINCIPAL_BUDGET_PERIOD                   = var.principal_budget_period
     USAGE_TTL                                 = var.usage_ttl
   }
+}
+
+// Upload budget notification email templates to S3
+// (templates may be too large to pass in as env vars)
+resource "aws_s3_bucket_object" "budget_notification_template_html" {
+  bucket  = local.budget_notification_templates_bucket
+  key     = "budget_notification_templates/html.tmpl"
+  content = var.budget_notification_template_html
+}
+resource "aws_s3_bucket_object" "budget_notification_template_text" {
+  bucket  = local.budget_notification_templates_bucket
+  key     = "budget_notification_templates/text.tmpl"
+  content = var.budget_notification_template_text
 }
 
 // Allow update_lease_status lambda to send emails with SES


### PR DESCRIPTION


## Proposed changes

When configuring email templates > 4kb in tfvars,
terraform apply would fail with:


> Error: Error creating Lambda function: InvalidParameterValueException: Lambda was unable to configure your environment variables because the environment variables you have provided exceeded the 4KB limit.


This fix moves the templates to S3 object (instead of env vars) so we are not bound by
the 4kb env var limitation


## Types of changes

<!--
What types of changes does your code introduce to the repo?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (changes to code, which do not change application behavior)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have filled out this PR template
- [x] I have read the [CONTRIBUTING](https://github.com/Optum/dce/blob/master/docs/CONTRIBUTING.md) doc
- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (`README.md`, inline comments, etc.)
- [x] I have updated the `CHANGELOG.md` under a `## next` release, with a short summary of my changes

