### PR TITLE
Update tflint version and include for MacOS. (#338)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Hardened `scripts/install_ci.sh` to be used by developers.
 - Added documenation for local developer environment setup.
 - Fix bug with delete lease, replace list method call with GetByAccountIdAndPrincipalId.
+- Fix to issue to include tflint package for MacOS user and upgrade version for Linux user.
 
 ## v0.29.0
 

--- a/scripts/install_ci.sh
+++ b/scripts/install_ci.sh
@@ -32,7 +32,11 @@ export GO111MODULE=off
 # as the other go tools.
 if [ -x "$(command -v wget)" ]; then
   if [ ! -x "$(command -v tflint)" ]; then
-    wget -q https://github.com/wata727/tflint/releases/download/v0.13.4/tflint_linux_amd64.zip -O /tmp/tflint.zip
+    if [[ $(uname -s) == "Darwin" ]]; then
+      wget -q https://github.com/wata727/tflint/releases/download/v0.15.4/tflint_darwin_amd64.zip -O /tmp/tflint.zip
+    else
+      wget -q https://github.com/wata727/tflint/releases/download/v0.15.4/tflint_linux_amd64.zip -O /tmp/tflint.zip
+    fi
     (cd /tmp && unzip tflint.zip)
     chmod +x /tmp/tflint
     mv /tmp/tflint $GOBIN


### PR DESCRIPTION
## Proposed changes

Fix to `make test` where `install_ci.sh` file is installing a release of tflint that's compiled for linux,
so it's failing to run on my mac machine.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (changes to code, which do not change application behavior)

## Checklist

- [ ] I have filled out this PR template
- [ ] I have read the [CONTRIBUTING](https://github.com/Optum/dce/blob/master/docs/CONTRIBUTING.md) doc
- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (`README.md`, inline comments, etc.)
- [x] I have updated the `CHANGELOG.md` under a `## next` release, with a short summary of my changes


## Relevant Links
Issue https://github.com/Optum/dce/issues/338

## Further comments
