### PR TITLE
Bug: Admins authorized as users due to hardcoded string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added documenation for local developer environment setup.
 - Fix bug with delete lease, replace list method call with GetByAccountIdAndPrincipalId.
 - Fix to issue to include tflint package for MacOS user and upgrade version for Linux user.
+- Fixed a bug causing admins to be authorized as users.
 
 ## v0.29.0
 

--- a/cmd/lambda/leases/list.go
+++ b/cmd/lambda/leases/list.go
@@ -21,7 +21,6 @@ func GetLeases(w http.ResponseWriter, r *http.Request) {
 		response.WriteRequestValidationError(w, fmt.Sprintf("Error parsing query params: %s", err))
 		return
 	}
-
 	// If user is not an admin, they may only list their own leases
 	user := r.Context().Value(api.User{}).(*api.User)
 	if user.Role != api.AdminGroupName {

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -83,7 +83,6 @@ func (u *UserDetails) GetUser(reqCtx *events.APIGatewayProxyRequestContext) *Use
 		log.Printf("Did not get the current user.  Found %d instead of 1.", len(users.Users))
 		return &User{}
 	}
-
 	user := &User{
 		Role:     UserGroupName,
 		Username: *users.Users[0].Username,
@@ -122,7 +121,7 @@ func (u *UserDetails) isUserInAdminGroup(username string) (bool, error) {
 		return false, fmt.Errorf("Was not abile to query a users for its groups: %s", err)
 	}
 	for _, group := range groups.Groups {
-		if *group.GroupName == "Admins" {
+		if *group.GroupName == AdminGroupName {
 			return true, nil
 		}
 	}

--- a/pkg/api/user_test.go
+++ b/pkg/api/user_test.go
@@ -19,7 +19,7 @@ func TestUser(t *testing.T) {
 		mockCognitoIdp := &mocks.CognitoIdentityProviderAPI{}
 		userGetter := api.UserDetails{
 			CognitoUserPoolID:        "us_east_1-test",
-			RolesAttributesAdminName: "admin",
+			RolesAttributesAdminName: api.AdminGroupName,
 			CognitoClient:            mockCognitoIdp,
 		}
 
@@ -37,7 +37,7 @@ func TestUser(t *testing.T) {
 		mockCognitoIdp := &mocks.CognitoIdentityProviderAPI{}
 		userGetter := api.UserDetails{
 			CognitoUserPoolID:        "us_east_1-test",
-			RolesAttributesAdminName: "admins",
+			RolesAttributesAdminName: api.AdminGroupName,
 			CognitoClient:            mockCognitoIdp,
 		}
 
@@ -57,7 +57,7 @@ func TestUser(t *testing.T) {
 		}).Return(&cognitoidentityprovider.AdminListGroupsForUserOutput{
 			Groups: []*cognitoidentityprovider.GroupType{
 				{
-					GroupName: aws.String("Admins"),
+					GroupName: aws.String(api.AdminGroupName),
 				},
 			},
 		}, nil)
@@ -77,7 +77,7 @@ func TestUser(t *testing.T) {
 		mockCognitoIdp := &mocks.CognitoIdentityProviderAPI{}
 		userGetter := api.UserDetails{
 			CognitoUserPoolID:        "us_east_1-test",
-			RolesAttributesAdminName: "admins",
+			RolesAttributesAdminName: api.AdminGroupName,
 			CognitoClient:            mockCognitoIdp,
 		}
 
@@ -91,7 +91,7 @@ func TestUser(t *testing.T) {
 					Attributes: []*cognitoidentityprovider.AttributeType{
 						{
 							Name:  aws.String("custom:roles"),
-							Value: aws.String("group1, group2,group3, admins"),
+							Value: aws.String(fmt.Sprint("group1, group2,group3, ", api.AdminGroupName)),
 						},
 					},
 				},
@@ -119,7 +119,7 @@ func TestUser(t *testing.T) {
 		mockCognitoIdp := &mocks.CognitoIdentityProviderAPI{}
 		userGetter := api.UserDetails{
 			CognitoUserPoolID:        "us_east_1-test",
-			RolesAttributesAdminName: "admins",
+			RolesAttributesAdminName: api.AdminGroupName,
 			CognitoClient:            mockCognitoIdp,
 		}
 
@@ -133,7 +133,7 @@ func TestUser(t *testing.T) {
 					Attributes: []*cognitoidentityprovider.AttributeType{
 						{
 							Name:  aws.String("custom:roles"),
-							Value: aws.String("Group1,Group2,admins"),
+							Value: aws.String(fmt.Sprint("Group1,Group2,", api.AdminGroupName)),
 						},
 					},
 				},
@@ -155,7 +155,7 @@ func TestUser(t *testing.T) {
 		mockCognitoIdp := &mocks.CognitoIdentityProviderAPI{}
 		userGetter := api.UserDetails{
 			CognitoUserPoolID:        "us_east_1-test",
-			RolesAttributesAdminName: "admins",
+			RolesAttributesAdminName: api.AdminGroupName,
 			CognitoClient:            mockCognitoIdp,
 		}
 
@@ -197,7 +197,7 @@ func TestUser(t *testing.T) {
 		mockCognitoIdp := &mocks.CognitoIdentityProviderAPI{}
 		userGetter := api.UserDetails{
 			CognitoUserPoolID:        "us_east_1-test",
-			RolesAttributesAdminName: "admins",
+			RolesAttributesAdminName: api.AdminGroupName,
 			CognitoClient:            mockCognitoIdp,
 		}
 
@@ -223,7 +223,7 @@ func TestUser(t *testing.T) {
 		}).Return(&cognitoidentityprovider.AdminListGroupsForUserOutput{
 			Groups: []*cognitoidentityprovider.GroupType{
 				{
-					GroupName: aws.String("Admins"),
+					GroupName: aws.String(api.AdminGroupName),
 				},
 			},
 		}, nil)
@@ -242,7 +242,7 @@ func TestUser(t *testing.T) {
 		mockCognitoIdp := &mocks.CognitoIdentityProviderAPI{}
 		userGetter := api.UserDetails{
 			CognitoUserPoolID:        "us_east_1-test",
-			RolesAttributesAdminName: "admins",
+			RolesAttributesAdminName: api.AdminGroupName,
 			CognitoClient:            mockCognitoIdp,
 		}
 
@@ -287,7 +287,7 @@ func TestUser(t *testing.T) {
 		mockCognitoIdp := &mocks.CognitoIdentityProviderAPI{}
 		userGetter := api.UserDetails{
 			CognitoUserPoolID:        "us_east_1-test",
-			RolesAttributesAdminName: "admins",
+			RolesAttributesAdminName: api.AdminGroupName,
 			CognitoClient:            mockCognitoIdp,
 		}
 
@@ -316,7 +316,7 @@ func TestUser(t *testing.T) {
 					GroupName: aws.String("Users"),
 				},
 				{
-					GroupName: aws.String("Admins"),
+					GroupName: aws.String(api.AdminGroupName),
 				},
 			},
 		}, nil)
@@ -335,7 +335,7 @@ func TestUser(t *testing.T) {
 		mockCognitoIdp := &mocks.CognitoIdentityProviderAPI{}
 		userGetter := api.UserDetails{
 			CognitoUserPoolID:        "us_east_1-test",
-			RolesAttributesAdminName: "admins",
+			RolesAttributesAdminName: api.AdminGroupName,
 			CognitoClient:            mockCognitoIdp,
 		}
 


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Discovered while investigating https://github.com/Optum/dce-cli/issues/58. It seems that DCE was using a hardcoded string 'Admins' to check whether users belonged to the Admin group. This was causing admins to be authorized as users.

## Types of changes

<!--
What types of changes does your code introduce to the repo?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (changes to code, which do not change application behavior)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have filled out this PR template
- [x] I have read the [CONTRIBUTING](https://github.com/Optum/dce/blob/master/docs/CONTRIBUTING.md) doc
- [x] I have added automated tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (`README.md`, inline comments, etc.)
- [x] I have updated the `CHANGELOG.md` under a `## next` release, with a short summary of my changes


## Relevant Links

<!--
Include any links that may be useful for reviewers. This could include

- Related Pull Requests that are waiting for review,
- Relevant 3rd party documentation
- etc.
-->


## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->


