### PR TITLE
feat: encrypt SNS topics by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add new secondary index 'PrincipalIdLastModifiedOn' for Lease table with range key as LastModifiedOn to get the records sort by last-modified
 - Update pkg/data/leases.go queryLeases method to use new IndexName PrincipalIdLastModifiedOn instead of existing IndexName PrincipalId in to get leases in order
 - Fix extra characters being added on inputs passed to deployment script in pipeline #433
+- Encrypt SNS topics by default
 
 ## v0.33.9
 

--- a/modules/accounts_lambda.tf
+++ b/modules/accounts_lambda.tf
@@ -35,11 +35,13 @@ module "accounts_lambda" {
 }
 
 resource "aws_sns_topic" "account_created" {
-  name = "account-created-${var.namespace}"
-  tags = var.global_tags
+  name              = "account-created-${var.namespace}"
+  kms_master_key_id = local.sns_encryption_key_id
+  tags              = var.global_tags
 }
 
 resource "aws_sns_topic" "account_deleted" {
-  name = "account-deleted-${var.namespace}"
-  tags = var.global_tags
+  name              = "account-deleted-${var.namespace}"
+  kms_master_key_id = local.sns_encryption_key_id
+  tags              = var.global_tags
 }

--- a/modules/alarms_sns.tf
+++ b/modules/alarms_sns.tf
@@ -1,6 +1,7 @@
 # Make a topic
 resource "aws_sns_topic" "alarms_topic" {
-  name = "alarms-${var.namespace}"
+  name              = "alarms-${var.namespace}"
+  kms_master_key_id = local.sns_encryption_key_id
 }
 
 resource "aws_sns_topic_policy" "alarms_policy" {

--- a/modules/leases_lambda.tf
+++ b/modules/leases_lambda.tf
@@ -27,22 +27,26 @@ module "leases_lambda" {
 }
 
 resource "aws_sns_topic" "lease_added" {
-  name = "lease-added-${var.namespace}"
-  tags = var.global_tags
+  name              = "lease-added-${var.namespace}"
+  kms_master_key_id = local.sns_encryption_key_id
+  tags              = var.global_tags
 }
 
 resource "aws_sns_topic" "lease_removed" {
-  name = "lease-removed-${var.namespace}"
-  tags = var.global_tags
+  name              = "lease-removed-${var.namespace}"
+  kms_master_key_id = local.sns_encryption_key_id
+  tags              = var.global_tags
 }
 
 
 resource "aws_sns_topic" "lease_locked" {
-  name = "lease-locked-${var.namespace}"
-  tags = var.global_tags
+  name              = "lease-locked-${var.namespace}"
+  kms_master_key_id = local.sns_encryption_key_id
+  tags              = var.global_tags
 }
 
 resource "aws_sns_topic" "lease_unlocked" {
-  name = "lease-unlocked-${var.namespace}"
-  tags = var.global_tags
+  name              = "lease-unlocked-${var.namespace}"
+  kms_master_key_id = local.sns_encryption_key_id
+  tags              = var.global_tags
 }

--- a/modules/main.tf
+++ b/modules/main.tf
@@ -12,6 +12,7 @@ data "aws_caller_identity" "current" {
 }
 
 locals {
-  account_id = data.aws_caller_identity.current.account_id
+  account_id            = data.aws_caller_identity.current.account_id
+  sns_encryption_key_id = "alias/aws/sns"
 }
 

--- a/modules/reset_codebuild.tf
+++ b/modules/reset_codebuild.tf
@@ -222,6 +222,7 @@ resource "aws_cloudwatch_metric_alarm" "reset_failed_builds" {
 
 
 resource "aws_sns_topic" "reset_complete" {
-  name = "account-reset-complete-${var.namespace}"
-  tags = var.global_tags
+  name              = "account-reset-complete-${var.namespace}"
+  kms_master_key_id = local.sns_encryption_key_id
+  tags              = var.global_tags
 }


### PR DESCRIPTION
## Proposed changes

Enable server-side encryption (SSE) for SNS topics using the default AWS managed KMS key for SNS: **alias/aws/sns**


## Types of changes

<!--
What types of changes does your code introduce to the repo?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (changes to code, which do not change application behavior)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have filled out this PR template
- [ ] I have read the [CONTRIBUTING](https://github.com/Optum/dce/blob/master/docs/CONTRIBUTING.md) doc
- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (`README.md`, inline comments, etc.)
- [x] I have updated the `CHANGELOG.md` under a `## next` release, with a short summary of my changes


## Relevant Links

<!--
Include any links that may be useful for reviewers. This could include

- Related Pull Requests that are waiting for review,
- Relevant 3rd party documentation
- etc.
-->


## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->


