### PR TITLE
Issue #447 InvalidBucketAclWithObjectOwnership error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## next
+
+- Fix: remove acl from atifact bucket to fix InvalidBucketAclWithObjectOwnership error
 ## v0.34.0
 
 - Fix: get latest aws-nuke release. (#432)

--- a/modules/artifacts_bucket.tf
+++ b/modules/artifacts_bucket.tf
@@ -9,9 +9,6 @@ locals {
 resource "aws_s3_bucket" "artifacts" {
   bucket = local.artifact_bucket_name
 
-  # Allow S3 access logs to be written to this bucket
-  acl = "log-delivery-write"
-
   # Allow Terraform to destroy the bucket
   # (so ephemeral PR environments can be torn down)
   force_destroy = true


### PR DESCRIPTION
## Remove ACL from artifacts bucket

Recent changes to AWS S3 default bucket policy have broken the install. Removing ACL from the bucket allows the installation to proceed.



## Types of changes


- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (changes to code, which do not change application behavior)

## Checklist

- [X] I have filled out this PR template
- [X] I have read the [CONTRIBUTING](https://github.com/Optum/dce/blob/master/docs/CONTRIBUTING.md) doc
- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (`README.md`, inline comments, etc.)
- [X] I have updated the `CHANGELOG.md` under a `## next` release, with a short summary of my changes


## Relevant Links

AWS Docs(https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html)


