### PR TITLE
Fix swagger definition of usage

### DIFF
--- a/modules/swagger.yaml
+++ b/modules/swagger.yaml
@@ -999,27 +999,29 @@ definitions:
       and it was rolled back.
   usage:
     description: "usage cost of the aws account from start date to end date"
-    type: object
-    properties:
-      principalId:
-        type: string
-        description: >
-          principalId of the user who owns the lease of the AWS account
-      accountId:
-        type: string
-        description: accountId of the AWS account
-      startDate:
-        type: number
-        description: usage start date as Epoch Timestamp
-      endDate:
-        type: number
-        description: usage end date as Epoch Timestamp
-      costAmount:
-        type: number
-        description: usage cost Amount of AWS account for given period
-      costCurrency:
-        type: string
-        description: usage cost currency
-      timeToLive:
-        type: number
-        description: ttl attribute as Epoch Timestamp
+    type: array
+    items:
+      type: object
+      properties:
+        principalId:
+          type: string
+          description: >
+            principalId of the user who owns the lease of the AWS account
+        accountId:
+          type: string
+          description: accountId of the AWS account
+        startDate:
+          type: number
+          description: usage start date as Epoch Timestamp
+        endDate:
+          type: number
+          description: usage end date as Epoch Timestamp
+        costAmount:
+          type: number
+          description: usage cost Amount of AWS account for given period
+        costCurrency:
+          type: string
+          description: usage cost currency
+        timeToLive:
+          type: number
+          description: ttl attribute as Epoch Timestamp


### PR DESCRIPTION
## Proposed changes
the dce-cli currently fails with

```
dce usage -e 1725645854 -s 1725645000
err:  json: cannot unmarshal array into Go value of type operations.GetUsageOKBody
```

because it's expecting a single value but the API returns an array.

## Types of changes

<!--
What types of changes does your code introduce to the repo?
Put an `x` in the boxes that apply
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (changes to code, which do not change application behavior)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have filled out this PR template
- [ ] I have read the [CONTRIBUTING](https://github.com/Optum/dce/blob/master/docs/CONTRIBUTING.md) doc
- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (`README.md`, inline comments, etc.)
- [ ] I have updated the `CHANGELOG.md` under a `## next` release, with a short summary of my changes


## Relevant Links

<!--
Include any links that may be useful for reviewers. This could include

- Related Pull Requests that are waiting for review,
- Relevant 3rd party documentation
- etc.
-->


## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->


